### PR TITLE
Updates readme with note about aws-sdk gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Refile.cache = Refile::Backend::S3.new(prefix: "cache", **aws)
 Refile.store = Refile::Backend::S3.new(prefix: "store", **aws)
 ```
 
+And add to your Gemfile:
+```ruby
+gem "aws-sdk"
+```
+
 Try this in the quick start example above and your files are now uploaded to
 S3.
 


### PR DESCRIPTION
Seems like refile only has a development dependency to `aws-sdk`, unless it's supposed to be a runtime dependency, I think it's reasonable to add a note to the readme stating that you need to add it yourself.
