### PR TITLE
Delay success event until after input value has been set

### DIFF
--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -26,9 +26,9 @@
           input.dispatchEvent(new CustomEvent("upload:complete", { detail: xhr.responseText, bubbles: true }));
           if((xhr.status >= 200 && xhr.status < 300) || xhr.status === 304) {
             var id = input.dataset.id || JSON.parse(xhr.responseText).id;
-            input.dispatchEvent(new CustomEvent("upload:success", { detail: xhr.responseText, bubbles: true }));
             input.previousSibling.value = id;
             input.removeAttribute("name");
+            input.dispatchEvent(new CustomEvent("upload:success", { detail: xhr.responseText, bubbles: true }));
           } else {
             input.dispatchEvent(new CustomEvent("upload:failure", { detail: xhr.responseText, bubbles: true }));
           }


### PR DESCRIPTION
Not sure if this is intended behaviour, but shouldn't the success event fire after the `input.previousSibling.value = id;` line? That way I can access the newly uploaded file upon `upload:success`. Or am I supposed to do that in some other way?
