### PR TITLE
Fix attachment_url for apps without a root URL

### DIFF
--- a/app/helpers/attachment_helper.rb
+++ b/app/helpers/attachment_helper.rb
@@ -5,7 +5,7 @@ module AttachmentHelper
     filename ||= name.to_s
 
     backend_name = Refile.backends.key(file.backend)
-    host = Refile.host || root_url
+    host = Refile.host || request.base_url
 
     filename = filename.parameterize("_")
     filename << "." << format.to_s if format
@@ -30,7 +30,7 @@ module AttachmentHelper
       cache = options[:object].send(:"#{method}_attachment").cache
 
       if options[:direct]
-        host = Refile.host || root_url
+        host = Refile.host || request.base_url
         backend_name = Refile.backends.key(cache)
 
         options[:data] ||= {}


### PR DESCRIPTION
Hello @jnicklas and great job with this gem!

I tried using your gem in a Rails app that does not declare a `root` route in `config/routes.rb` and I found that it does not work
because `attachment_url` is falling back to `root_url`.

If I understand the code correctly, you should fall back to `request.base_url` instead, which will give you the base URL for you app, such as `http://localhost:3000` while you are developing.
