### PR TITLE
Additional AWS::S3 options for Backend::S3.

### DIFF
--- a/lib/refile/backend/s3.rb
+++ b/lib/refile/backend/s3.rb
@@ -59,10 +59,11 @@ module Refile
 
       attr_reader :access_key_id
 
-      def initialize(access_key_id:, secret_access_key:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new)
+      def initialize(access_key_id:, secret_access_key:, bucket:, max_size: nil, prefix: nil, hasher: Refile::RandomHasher.new, **s3_options)
         @access_key_id = access_key_id
         @secret_access_key = secret_access_key
-        @s3 = AWS::S3.new(access_key_id: access_key_id, secret_access_key: secret_access_key)
+        @s3_options = { access_key_id: access_key_id, secret_access_key: secret_access_key }.merge s3_options
+        @s3 = AWS::S3.new @s3_options
         @bucket_name = bucket
         @bucket = @s3.buckets[@bucket_name]
         @hasher = hasher


### PR DESCRIPTION
Added the option to provide additional arguments for AWS::S3.
For example https://github.com/jubos/fake-s3 can be used now with the following setup:

```
{ secret_access_key: 'your_secret_access_key',
  access_key_id: 'your_secret_access_key',
  bucket: 'your_bucket',
  s3_port: 4567,
  s3_endpoint: 'localhost',
  use_ssl: false,
  s3_force_path_style: true }
```
