### PR TITLE
Adds Expires header for GET requests to Refile::App

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -12,6 +12,7 @@ module Refile
       `clear!(:confirm)` if you're sure you want to do this"
     end
   end
+  ONE_YEAR_IN_SECONDS = 31_557_600
 
   class << self
     # The number of bytes to read when files are streamed. Refile
@@ -55,6 +56,9 @@ module Refile
     #
     # @return [String]
     attr_accessor :allow_origin
+
+    # Value for Cache-Control: max-age=<value in seconds> header
+    attr_accessor :content_max_age
 
     # Where should the rack application be mounted?
     # The default is 'attachments'
@@ -193,4 +197,5 @@ Refile.configure do |config|
   config.logger = Logger.new(STDOUT)
   config.mount_point = "attachments"
   config.automount = true
+  config.content_max_age = Refile::ONE_YEAR_IN_SECONDS
 end

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -21,22 +21,27 @@ module Refile
     end
 
     get "/:backend/:id/:filename" do
+      set_expires_header
       stream_file(file)
     end
 
     get "/:backend/:processor/:id/:file_basename.:extension" do
+      set_expires_header
       stream_file processor.call(file, format: params[:extension])
     end
 
     get "/:backend/:processor/:id/:filename" do
+      set_expires_header
       stream_file processor.call(file)
     end
 
     get "/:backend/:processor/*/:id/:file_basename.:extension" do
+      set_expires_header
       stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension])
     end
 
     get "/:backend/:processor/*/:id/:filename" do
+      set_expires_header
       stream_file processor.call(file, *params[:splat].first.split("/"))
     end
 
@@ -68,6 +73,10 @@ module Refile
     end
 
   private
+
+    def set_expires_header
+      expires Refile.content_max_age, :public, :must_revalidate
+    end
 
     def logger
       Refile.logger


### PR DESCRIPTION
Adds Expires header for GET requests to Refile::App so responses could be cached by browser/proxies.
Fixes #9 
