### PR TITLE
Speed up IO work

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -16,14 +16,6 @@ module Refile
   ONE_YEAR_IN_SECONDS = 31_557_600
 
   class << self
-    # The number of bytes to read when files are streamed. Refile
-    # uses this in a couple of places where files should be streamed
-    # in a memory efficient way instead of reading the entire file into
-    # memory at once. The default value of this is `3000`.
-    #
-    # @return [Fixnum]
-    attr_accessor :read_chunk_size
-
     # A shortcut to the instance of the Rack application. This should be
     # set when the application is initialized. `refile/rails` sets this
     # value.
@@ -210,10 +202,6 @@ module Refile
 end
 
 Refile.configure do |config|
-  # FIXME: what is a sane default here? This is a little less than a
-  # memory page, which seemed like a good default, is there a better
-  # one?
-  config.read_chunk_size = 3000
   config.direct_upload = ["cache"]
   config.allow_origin = "*"
   config.logger = Logger.new(STDOUT)

--- a/lib/refile/backend/file_system.rb
+++ b/lib/refile/backend/file_system.rb
@@ -15,19 +15,7 @@ module Refile
         Refile.verify_uploadable(uploadable, @max_size)
 
         id = @hasher.hash(uploadable)
-
-        if uploadable.respond_to?(:path) and ::File.exist?(uploadable.path)
-          FileUtils.cp(uploadable.path, path(id))
-        else
-          ::File.open(path(id), "wb") do |file|
-            buffer = "" # reuse the same buffer
-            until uploadable.eof?
-              uploadable.read(Refile.read_chunk_size, buffer)
-              file.write(buffer)
-            end
-            uploadable.close
-          end
-        end
+        IO.copy_stream(uploadable, path(id))
 
         Refile::File.new(self, id)
       end

--- a/lib/refile/file.rb
+++ b/lib/refile/file.rb
@@ -36,21 +36,10 @@ module Refile
     end
 
     def download
-      tempfile = Tempfile.new(id)
-      tempfile.binmode
-      each do |chunk|
-        tempfile.write(chunk)
-      end
-      close
-      tempfile.close
-      tempfile
-    end
+      return io if io.is_a?(Tempfile)
 
-    def each
-      if block_given?
-        yield(read(Refile.read_chunk_size)) until eof?
-      else
-        to_enum
+      Tempfile.new(id, binmode: true).tap do |tempfile|
+        IO.copy_stream(io, tempfile)
       end
     end
 

--- a/lib/refile/image_processing.rb
+++ b/lib/refile/image_processing.rb
@@ -60,14 +60,11 @@ module Refile
     end
 
     def call(file, *args, format: nil)
-      path = file.download.path
-      img = ::MiniMagick::Image.open(path)
+      img = ::MiniMagick::Image.new(file.path)
       img.format(format.to_s.downcase) if format
       send(@method, img, *args)
 
-      img.write(path)
-
-      ::File.open(path, "rb")
+      ::File.open(img.path, "rb")
     end
   end
 end

--- a/spec/refile/backend/file_system_spec.rb
+++ b/spec/refile/backend/file_system_spec.rb
@@ -2,29 +2,4 @@ RSpec.describe Refile::Backend::FileSystem do
   let(:backend) { Refile::Backend::FileSystem.new(File.expand_path("tmp/store1", Dir.pwd), max_size: 100) }
 
   it_behaves_like :backend
-
-  describe "#upload" do
-    it "efficiently copies a file if it has a path" do
-      path = File.expand_path("tmp/test.txt", Dir.pwd)
-      File.write(path, "hello")
-
-      uploadable = Refile::FileDouble.new("wrong")
-      allow(uploadable).to receive(:path).and_return(path)
-
-      file = backend.upload(uploadable)
-
-      expect(backend.get(file.id).read).to eq("hello")
-    end
-
-    it "ignores path if it doesn't exist" do
-      path = File.expand_path("tmp/doesnotexist.txt", Dir.pwd)
-
-      uploadable = Refile::FileDouble.new("yes")
-      allow(uploadable).to receive(:path).and_return(path)
-
-      file = backend.upload(uploadable)
-
-      expect(backend.get(file.id).read).to eq("yes")
-    end
-  end
 end

--- a/spec/refile/backend_examples.rb
+++ b/spec/refile/backend_examples.rb
@@ -179,25 +179,6 @@ RSpec.shared_examples_for :backend do
       end
     end
 
-    describe "#each" do
-      it "can read file contents" do
-        file = backend.upload(uploadable)
-
-        buffer = ""
-        file.each do |chunk|
-          buffer << chunk
-        end
-
-        expect(buffer).to eq("hello")
-      end
-
-      it "returns an enumerator when no block given" do
-        file = backend.upload(uploadable)
-
-        expect(file.each.to_a.join).to eq("hello")
-      end
-    end
-
     describe "#download" do
       it "returns a downloaded tempfile" do
         file = backend.upload(uploadable)

--- a/spec/refile/spec_helper.rb
+++ b/spec/refile/spec_helper.rb
@@ -31,9 +31,8 @@ end
 Refile.processor(:upcase, proc { |file| StringIO.new(file.read.upcase) })
 
 Refile.processor(:concat) do |file, *words|
-  content = File.read(file.download.path)
   tempfile = Tempfile.new("concat")
-  tempfile.write(content)
+  tempfile.write(file.read)
   words.each do |word|
     tempfile.write(word)
   end


### PR DESCRIPTION
Utilizing `IO.copy_stream` was a bit difficult to implement, so I split it into multiple commits. Detailed argumentation for each commit is in their description, so I will just summarize here.

When we're copying IOs, we want to do it in the fastest and most memory efficient way possible. `IO.copy_steam` does just that. I learned about it from a RubyTapas (series about implementing the `tail` UNIX command), and Avdi Grimm said that in his personal benchmark "it performs close to an order of magnitude faster" than manual `#read` & `#write`.

Utilizing `IO.copy_stream` requires us to use real IO objects, so we have to remove the loose requirements of just responding to 4 methods (`#eof?`, `#read`, `#close` and `#size`). We don't lose anything by this, because I can't imagine people not using real IO objects. That means we also have to simplify the S3 implementation, which I find positive.

If find the S3 simplification justified because files will almost always have to be processed before displaying, meaning that they will have to be downloaded first. This downloading is now much more efficient because of `IO.copy_stream`. We also get a bonus that instead of streaming the file we could just use `#send_file`, which enables us to assign filenames like the documentation suggests.

I know this is quite a bit, but these changes were all intertwined so that's why they're together. I know that this breaks any backend whose `#open` method doesn't return an IO object. Let me know what you think.
