### PR TITLE
Require "refile/signature"

### DIFF
--- a/lib/refile/backend/s3.rb
+++ b/lib/refile/backend/s3.rb
@@ -1,6 +1,8 @@
 require "aws-sdk"
 require "open-uri"
 
+require "refile/signature"
+
 module Refile
   module Backend
     # A refile backend which stores files in Amazon S3


### PR DESCRIPTION
It turns out that when I was solving merge conflicts in #64, the `require
"refile/signature"` somehow got lost :worried: 

I know I ran the tests for S3, I'm wondering how they passed.
