### PR TITLE
Give name to the #attachment's anonymous module

### DIFF
--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -86,6 +86,9 @@ module Refile
 
         define_method "remote_#{name}_url" do
         end
+
+        define_singleton_method("to_s")    { "Refile::Attachment(#{name})" }
+        define_singleton_method("inspect") { "Refile::Attachment(#{name})" }
       end
 
       include mod

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -358,4 +358,11 @@ describe Refile::Attachment do
       expect(instance.document).to be_nil
     end
   end
+
+  it "includes the module with methods in an instrospectable way" do
+    expect { puts klass.ancestors }
+      .to output(/Refile::Attachment\(document\)/).to_stdout
+    expect { p klass.ancestors }
+      .to output(/Refile::Attachment\(document\)/).to_stdout
+  end
 end


### PR DESCRIPTION
One RubyTapas motivated me that whenever I'm creating an anonymous module like this, to always try to make the ancestor chain prettier.

Before:

``` rb
class User < ActiveRecord::Base
  attachment :avatar
end

User.ancestors #=> [User(...), #<Module:0x007fd08af414d0>, ...]
```

After:

``` rb
class User < ActiveRecord::Base
  attachment :avatar
end

User.ancestors #=> [User(...), Refile::Attachment(avatar), ...]
```
