### PR TITLE
Refile::CustomLogger adds simple logging of requests to Refile::App.

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -220,6 +220,7 @@ module Refile
   require "refile/attachment"
   require "refile/random_hasher"
   require "refile/file"
+  require "refile/custom_logger"
   require "refile/app"
   require "refile/backend/file_system"
 end

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -21,6 +21,7 @@ module Refile
       set :sessions, false
       set :logging, false
       set :dump_errors, false
+      use CustomLogger, "Refile::App", Refile.logger
     end
 
     before do

--- a/lib/refile/custom_logger.rb
+++ b/lib/refile/custom_logger.rb
@@ -1,0 +1,35 @@
+require "rack/body_proxy"
+module Refile
+  class CustomLogger
+    LOG_FORMAT = %(%s: [%s] %s "%s%s" %d %0.1fms\n)
+
+    def initialize(app, prefix = nil, logger = nil)
+      @app, @prefix, @logger = app, prefix, logger
+    end
+
+    def call(env)
+      began_at = Time.now
+      status, header, body = @app.call(env)
+      header = Rack::Utils::HeaderHash.new(header)
+      body = Rack::BodyProxy.new(body) { log(env, status, began_at) }
+      [status, header, body]
+    end
+
+  private
+
+    def log(env, status, began_at)
+      now = Time.now
+      logger = @logger || env["rack.errors"]
+      logger.write format(
+        LOG_FORMAT,
+        @prefix,
+        now.strftime("%F %T %z"),
+        env["REQUEST_METHOD"],
+        env["PATH_INFO"],
+        env["QUERY_STRING"].empty? ? "" : "?" + env["QUERY_STRING"],
+        status.to_s[0..3],
+        (now - began_at) * 1000
+      )
+    end
+  end
+end


### PR DESCRIPTION
This commit adds custom logger to Refile::App with duration tracking.
In the end Rails log file looks like:

```
Started GET "/attachments/store/316216/original_file.jpg" for 127.0.0.1 at 2014-12-28 15:43:31 +0200
Refile::App: [2014-12-28 15:43:32 +0200] GET "/store/316216/original_file.jpg" 200 225.5ms


Started GET "/attachments/store/316217/original_file.jpg" for 127.0.0.1 at 2014-12-28 15:43:41 +0200
Refile::App: Could not find attachment by id: 316217
Refile::App: [2014-12-28 15:43:41 +0200] GET "/store/316217/original_file.jpg" 404 1.5ms
```

Refile::CustomLogger is simplified Rack::CommonLogger with basic(most useful information)
