### PR TITLE
Backend should know file content type

### DIFF
--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -102,8 +102,7 @@ module Refile
       end
 
       filename = request.path.split("/").last
-
-      send_file path, filename: filename, disposition: "inline", type: ::File.extname(request.path)
+      send_file path, filename: filename, disposition: "inline", type: file_content_type
     end
 
     def backend
@@ -115,8 +114,11 @@ module Refile
       backend
     end
 
+    attr_reader :file_content_type
+
     def file
       file = backend.get(params[:id])
+      @file_content_type = file.type
       unless file.exists?
         log_error("Could not find attachment by id: #{params[:id]}")
         halt 404

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -102,7 +102,7 @@ module Refile
       end
 
       filename = request.path.split("/").last
-      send_file path, filename: filename, disposition: "inline", type: file_content_type
+      send_file path, filename: filename, disposition: "inline", type: file_content_type || ::File.extname(request.path)
     end
 
     def backend

--- a/lib/refile/backend/file_system.rb
+++ b/lib/refile/backend/file_system.rb
@@ -84,6 +84,16 @@ module Refile
         ::File.size(path(id)) if exists?(id)
       end
 
+      # Return the mime type of the uploaded file.
+      #
+      # @param [Sring] id           The id of the file
+      # @return [String]            The file's mime type
+      verify_id def type(id)
+        return unless exists?(id)
+        content_type = MIME::Types.of(::File.basename(path(id))).first
+        content_type.to_s if content_type
+      end
+
       # Return whether the file with the given id exists in this backend.
       #
       # @param [Sring] id           The id of the file

--- a/lib/refile/backend/s3.rb
+++ b/lib/refile/backend/s3.rb
@@ -52,7 +52,7 @@ module Refile
         if uploadable.is_a?(Refile::File) and uploadable.backend.is_a?(S3) and uploadable.backend.access_key_id == access_key_id
           uploadable.backend.object(uploadable.id).copy_to(object(id))
         else
-          object(id).write(uploadable, content_length: uploadable.size)
+          object(id).write(uploadable, content_length: uploadable.size, content_type: Refile.extract_content_type(uploadable))
         end
 
         Refile::File.new(self, id)
@@ -103,6 +103,16 @@ module Refile
       # @return [Integer]           The file's size
       verify_id def size(id)
         object(id).content_length
+      rescue AWS::S3::Errors::NoSuchKey
+        nil
+      end
+
+      # Return the mime type of the uploaded file.
+      #
+      # @param [Sring] id           The id of the file
+      # @return [String]            The file's mime type
+      verify_id def type(id)
+        object(id).content_type
       rescue AWS::S3::Errors::NoSuchKey
         nil
       end

--- a/lib/refile/file.rb
+++ b/lib/refile/file.rb
@@ -41,6 +41,11 @@ module Refile
       backend.size(id)
     end
 
+    # @return [String] the reported content type of file
+    def type
+      backend.type(id)
+    end
+
     # Remove the file from the backend.
     #
     # @return [void]


### PR DESCRIPTION
@jnicklas Hey Jonas, thanks for a great gem!

The only thing I dislike right now, is the need to manually take care of Content-Type. What if backend could figure it out for us? We could store it in S3 or grab from the file system without the need to save it to the database or provide in the helper options. Here is the simplest code to make it work, just a proof of concept. What do you think?