### PR TITLE
Add ActiveRecord test for replacing files

### DIFF
--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -84,6 +84,20 @@ describe Refile::ActiveRecord::Attachment do
       expect(post.document.read).to eq("hello")
       expect(Refile.store.read(post.document.id)).to eq("hello")
     end
+
+    it "replaces an existing file" do
+      post = klass.new
+      post.document = Refile::FileDouble.new("hello")
+      post.save
+      old_document = post.document
+
+      post = klass.find(post.id)
+      post.document = Refile::FileDouble.new("hello")
+      post.save
+
+      expect(Refile.store.read(post.document.id)).to eq("hello")
+      expect(post.document.id).not_to be eq old_document.id
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
Assignment of the attachment attribute caches the attachment, but doesn't change any actual columns on the model. Sequel, for example, won't save the record if no columns were changed, thus when replacing an attachment on an existing record it won't trigger the `before_save` callback. So, I thought it's good to have this check for ActiveRecord, just in case.