### PR TITLE
Set RACK_ENV to "test" in spec_helper.rb

### DIFF
--- a/spec/refile/spec_helper.rb
+++ b/spec/refile/spec_helper.rb
@@ -1,3 +1,5 @@
+ENV["RACK_ENV"] = "test"
+
 require "refile"
 require "refile/backend_examples"
 require "webmock/rspec"


### PR DESCRIPTION
When I run `bundle exec rspec`, then both `Refile::App` and Rails test app are run in "development" environment (which causes Rails to fail, because its `secret_key_base` is only set in "test"). I know I could prepend `RACK_ENV=test` to the shell command, but since this is a standard practice in test environments (rspec-rails and minitest-rails generate it by default), I thought it would nice if Refile test suite also had it.