### PR TITLE
Initialize values in method signature instead of using the ||= operator.

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -235,13 +235,11 @@ module Refile
     # @param [String, nil] host            Override the host
     # @param [String, nil] prefix          Adds a prefix to the URL if the application is not mounted at root
     # @return [String, nil]                The generated URL
-    def attachment_url(object, name, *args, prefix: nil, filename: nil, format: nil, host: nil)
+    def attachment_url(object, name, *args, prefix: Refile.mount_point, filename: nil, format: nil, host: Refile.host)
       attacher = object.send(:"#{name}_attacher")
       file = attacher.get
       return unless file
 
-      host ||= Refile.host
-      prefix ||= Refile.mount_point
       filename ||= attacher.basename || name.to_s
       format ||= attacher.extension
 


### PR DESCRIPTION
Cleans up the attachment_url method a bit.