### PR TITLE
Make Refile compatible with JRuby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ gem "capybara"
 gem "pry"
 gem "aws-sdk"
 gem "rack-test", "~> 0.6.2"
-gem "rails", "~> 4.1.8"
-gem "sqlite3"
+gem "rails", "~> 4.1.10"
+gem "sqlite3",                          platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
 gem "selenium-webdriver"
 gem "yard"
 gem "rubocop"
-gem "redcarpet"

--- a/lib/refile/file.rb
+++ b/lib/refile/file.rb
@@ -71,6 +71,7 @@ module Refile
 
       Tempfile.new(id, binmode: true).tap do |tempfile|
         IO.copy_stream(io, tempfile)
+        tempfile.rewind
       end
     end
 

--- a/spec/refile/spec_helper.rb
+++ b/spec/refile/spec_helper.rb
@@ -40,8 +40,8 @@ Refile.processor(:concat) do |file, *words|
   File.open(tempfile.path, "r")
 end
 
-Refile.processor(:convert_case) do |file, format:|
-  case format
+Refile.processor(:convert_case) do |file, options = {}|
+  case options[:format]
     when "up" then StringIO.new(file.read.upcase)
     when "down" then StringIO.new(file.read.downcase)
     else file

--- a/spec/refile/test_app.rb
+++ b/spec/refile/test_app.rb
@@ -6,7 +6,9 @@ require "jquery/rails"
 
 module Refile
   class TestApp < Rails::Application
-    config.session_store :cookie_store, key: "_refile_session"
+    config.middleware.delete "ActionDispatch::Cookies"
+    config.middleware.delete "ActionDispatch::Session::CookieStore"
+    config.middleware.delete "ActionDispatch::Flash"
     config.active_support.deprecation = :log
     config.eager_load = false
     config.action_dispatch.show_exceptions = false


### PR DESCRIPTION
1. MRI => `sqlite3`, JRuby => `activerecord-jdbcsqlite3-adapter`

2. Redcarpet has C extensions, which JRuby cannot use, and Redcarpet isn't being used in the test suite anyway.

3. In JRuby `IO.copy_stream` doesn't rewind the destination IO, so we rewind it. I reported it to JRuby, even though I don't really see it as a bug.

4. JRuby doesn't support keyword arguments in block arguments, @jnicklas already reported it, but I think it's easy enough for us to work around it.

5. Cookie middlewares use `ActiveSupport::MessageEncryptor`, which requires that a "Java Cryptography Extension" is installed on the system. Since we don't use cookies in tests, we can just remove them.

This PR is not complete, however. The last remaining error I wasn't able to solve. On normal file upload (`NormalPostsController#create` in the test app), the following error occurs:

```
Encoding::UndefinedConversionError: "\xFF" from ASCII-8BIT to UTF-8

./lib/refile/backend/file_system.rb:37:in `__script__'
./lib/refile/backend_macros.rb:31:in `upload'
./lib/refile/attacher.rb:91:in `cache!'
./lib/refile/attacher.rb:74:in `__script__'
./lib/refile/attachment.rb:58:in `attachment_CLOSURE_1_CLOSURE_3__attachment_CLOSURE_1_2'
./spec/refile/test_app/app/controllers/normal_posts_controller.rb:19:in `create'
./spec/refile/features/normal_upload_spec.rb:54:in `(root)'
```

This happens when `Refile::Backend::FileSystem` tries to `#upload` a file, during `IO.copy_stream`. This looks very similar to a [closed MRI bug](https://bugs.ruby-lang.org/issues/8767). I wanted to raise an issue on JRuby, but I wasn't able to successfully reproduce the bug.

I've determined that this error only happens when you use a wrapper around an IO. So, it fails for `ActionDispatch::Http::UploadedFile` (which wraps a Tempfile) and `Refile::File`. But if I pass the underlying IOs directly to `IO.copy_stream`, the error is gone. It only happens with actual image uploads, because they're binary, and not UTF-8 encoded.

This is the example which I think is supposed to fail in JRuby, but doesn't (I tested on 9.0.0.0.pre1):

```rb
require "forwardable"

IoWrapper = Struct.new(:io) do
  extend Forwardable
  delegate [:read, :eof?, :close, :size] => :io
end

io = File.open('spec/refile/fixtures/image.jpg', encoding: "ascii-8bit")
# Now io.external_encoding is equal to ASCII-8BIT, just like in the tests.
io_wrapper = IoWrapper.new(io)

IO.copy_stream(io_wrapper, "foo.jpg")
```