### PR TITLE
Add max_size directly to attachment

### DIFF
--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -36,7 +36,7 @@ module Refile
     # @return [void]
     # @ignore
     #   rubocop:disable Metrics/MethodLength
-    def attachment(name, cache: :cache, store: :store, raise_errors: true, type: nil, extension: nil, content_type: nil)
+    def attachment(name, cache: :cache, store: :store, raise_errors: true, type: nil, extension: nil, content_type: nil, max_size: nil)
       mod = Module.new do
         attacher = :"#{name}_attacher"
 
@@ -49,7 +49,8 @@ module Refile
               raise_errors: raise_errors,
               type: type,
               extension: extension,
-              content_type: content_type
+              content_type: content_type,
+              max_size: max_size
             ))
           end
         end

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -449,6 +449,26 @@ describe Refile::Attachment do
     end
   end
 
+  describe "with option `max_size: 4`" do
+    let(:options) { { max_size: 4, raise_errors: false } }
+
+    it "allows file with size less than max size to be uploaded" do
+      file = Refile::FileDouble.new("hi", content_type: "text/plain")
+      instance.document = file
+
+      expect(instance.document_attacher.errors).to be_empty
+      expect(Refile.cache.get(instance.document.id).exists?).to be_truthy
+    end
+
+    it "sets error when file with size greater than max size is uploaded" do
+      file = Refile::FileDouble.new("hello", content_type: "text/plain")
+      instance.document = file
+
+      expect(instance.document_attacher.errors).to eq([:too_large])
+      expect(instance.document).to be_nil
+    end
+  end
+
   describe "with option `type: :image`" do
     let(:options) { { type: :image, raise_errors: false } }
 


### PR DESCRIPTION
I know that `max_size` is already an option on the backend, but in my use-case I wanted two attachments to have different file size validations but be uploaded to the same backend. I think that it can be a pretty common use case (for me, I have one image and one video attachment on the same model).

Also, I thought it was a little weird that the `max_size` option is available only on the backend, while `content_type` and `extension` validations were available on the model.

After this commit I feel like there is a lot of validation code in the attacher, maybe some kind of `AttachmentValidator` class should exist (separate PR)?