### PR TITLE
Option to only use cache

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -74,6 +74,15 @@ module Refile
     # @return [Boolean]
     attr_accessor :automount
 
+    # Using your own custom routes, but still need access to the cache?
+    #
+    # If set to true then make sure automount is set to true as well. 
+    #
+    # The default is false.
+    #
+    # @return [Boolean]
+    attr_accessor :cacheonly
+
     # Value for generating signed attachment urls to protect from DoS
     #
     # @return [String]

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -81,7 +81,7 @@ module Refile
     # The default is false.
     #
     # @return [Boolean]
-    attr_accessor :cacheonly
+    attr_accessor :cache_only
 
     # Value for generating signed attachment urls to protect from DoS
     #
@@ -322,7 +322,7 @@ Refile.configure do |config|
   config.logger = Logger.new(STDOUT)
   config.mount_point = "attachments"
   config.automount = true
-  config.cacheonly = false
+  config.cache_only = false
   config.content_max_age = 60 * 60 * 24 * 365
   config.types[:image] = Refile::Type.new(:image, content_type: %w[image/jpeg image/gif image/png])
 end

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -313,6 +313,7 @@ Refile.configure do |config|
   config.logger = Logger.new(STDOUT)
   config.mount_point = "attachments"
   config.automount = true
+  config.cacheonly = false
   config.content_max_age = 60 * 60 * 24 * 365
   config.types[:image] = Refile::Type.new(:image, content_type: %w[image/jpeg image/gif image/png])
 end

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -32,24 +32,26 @@ module Refile
       end
     end
 
-    get "/:token/:backend/:id/:filename" do
-      stream_file file
-    end
-
-    get "/:token/:backend/:processor/:id/:file_basename.:extension" do
-      stream_file processor.call(file, format: params[:extension])
-    end
-
-    get "/:token/:backend/:processor/:id/:filename" do
-      stream_file processor.call(file)
-    end
-
-    get "/:token/:backend/:processor/*/:id/:file_basename.:extension" do
-      stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension])
-    end
-
-    get "/:token/:backend/:processor/*/:id/:filename" do
-      stream_file processor.call(file, *params[:splat].first.split("/"))
+    unless Refile.cacheonly
+      get "/:token/:backend/:id/:filename" do
+        stream_file file
+      end
+  
+      get "/:token/:backend/:processor/:id/:file_basename.:extension" do
+        stream_file processor.call(file, format: params[:extension])
+      end
+  
+      get "/:token/:backend/:processor/:id/:filename" do
+        stream_file processor.call(file)
+      end
+  
+      get "/:token/:backend/:processor/*/:id/:file_basename.:extension" do
+        stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension])
+      end
+  
+      get "/:token/:backend/:processor/*/:id/:filename" do
+        stream_file processor.call(file, *params[:splat].first.split("/"))
+      end
     end
 
     options "/:backend" do

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -32,7 +32,7 @@ module Refile
       end
     end
 
-    unless Refile.cacheonly
+    unless Refile.cache_only
       get "/:token/:backend/:id/:filename" do
         stream_file file
       end


### PR DESCRIPTION
Within my application, I've opted to exclude mounting the Sinatra application provided by Refile. However, this posed a problem when I tried to use the javascript callbacks when trying to access the cache to create a progress bar. I found that the implementation required to add this functionality, outside of including the Sinatra application, began creating obtrusive javascript. By adding an option to still include the Sinatra application, but optionally excluding the routes, I was able to accomplish this.

My goal was to protect the file uploads so that only authenticated users could access the files; authenticated logic handled separately. This pull request is fairly unobtrusive to the existing code base and adds what I consider to be important functionality.