### PR TITLE
Split part of Attacher off into AttachmentDefinition

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,9 @@ Style/SignalException:
 Style/IndentationWidth:
   Enabled: false
 
+Style/TrivialAccessors:
+  ExactNameMatch: true
+
 Lint/EndAlignment:
   AlignWith: variable
 

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -299,6 +299,7 @@ module Refile
   require "refile/signature"
   require "refile/type"
   require "refile/backend_macros"
+  require "refile/attachment_definition"
   require "refile/attacher"
   require "refile/attachment"
   require "refile/random_hasher"

--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -1,0 +1,46 @@
+module Refile
+  # @api private
+  class AttachmentDefinition
+    attr_reader :record, :name, :cache, :store, :options, :type, :valid_extensions, :valid_content_types
+    attr_accessor :remove
+
+    def initialize(name, cache:, store:, raise_errors: true, type: nil, extension: nil, content_type: nil)
+      @name = name
+      @raise_errors = raise_errors
+      @cache_name = cache
+      @store_name = store
+      @type = type
+      @valid_extensions = [extension].flatten if extension
+      @valid_content_types = [content_type].flatten if content_type
+      @valid_content_types ||= Refile.types.fetch(type).content_type if type
+    end
+
+    def cache
+      Refile.backends.fetch(@cache_name.to_s)
+    end
+
+    def store
+      Refile.backends.fetch(@store_name.to_s)
+    end
+
+    def accept
+      if valid_content_types
+        valid_content_types.join(",")
+      elsif valid_extensions
+        valid_extensions.map { |e| ".#{e}" }.join(",")
+      end
+    end
+
+    def raise_errors?
+      @raise_errors
+    end
+
+    def validate(attacher)
+      errors = []
+      errors << :invalid_extension if valid_extensions and not valid_extensions.include?(attacher.extension)
+      errors << :invalid_content_type if valid_content_types and not valid_content_types.include?(attacher.content_type)
+      errors << :too_large if cache.max_size and attacher.size and attacher.size >= cache.max_size
+      errors
+    end
+  end
+end

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -63,22 +63,22 @@ module Refile
     def attachment_field(object_name, method, object:, **options)
       options[:data] ||= {}
 
-      attacher = object.send(:"#{method}_attacher")
-      options[:accept] = attacher.accept
+      definition = object.send(:"#{method}_attachment_definition")
+      options[:accept] = definition.accept
 
       if options[:direct]
         host = options[:host] || Refile.host || request.base_url
-        backend_name = Refile.backends.key(attacher.cache)
+        backend_name = Refile.backends.key(definition.cache)
 
         url = ::File.join(host, main_app.refile_app_path, backend_name)
         options[:data].merge!(direct: true, as: "file", url: url)
       end
 
-      if options[:presigned] and attacher.cache.respond_to?(:presign)
-        options[:data].merge!(direct: true).merge!(attacher.cache.presign.as_json)
+      if options[:presigned] and definition.cache.respond_to?(:presign)
+        options[:data].merge!(direct: true).merge!(definition.cache.presign.as_json)
       end
 
-      html = hidden_field(object_name, method, value: attacher.data.to_json, object: object, id: nil)
+      html = hidden_field(object_name, method, value: object.send("#{method}_data").to_json, object: object, id: nil)
       html + file_field(object_name, method, options)
     end
   end

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -348,12 +348,12 @@ describe Refile::Attachment do
     end
   end
 
-  describe ":name_attacher.accept" do
+  describe ":name_definition.accept" do
     context "with `extension`" do
       let(:options) { { extension: %w[jpg png] } }
 
       it "returns an accept string" do
-        expect(instance.document_attacher.accept).to eq(".jpg,.png")
+        expect(instance.document_attachment_definition.accept).to eq(".jpg,.png")
       end
     end
 
@@ -361,7 +361,7 @@ describe Refile::Attachment do
       let(:options) { { content_type: %w[image/jpeg image/png], extension: "zip" } }
 
       it "returns an accept string" do
-        expect(instance.document_attacher.accept).to eq("image/jpeg,image/png")
+        expect(instance.document_attachment_definition.accept).to eq("image/jpeg,image/png")
       end
     end
   end


### PR DESCRIPTION
This splits Attacher into two classes, Attacher and AttachmentDefinition. AttachmentDefinition contains all the stuff from attacher that we can know in a static context (that is without having an instance of a record with an attachment). This might seem pretty pointless, but it's a first step towards fixing #6, everyone's favourite issue. (See also #135).

The problem we need to solve to implement for #6 is that we currently use Attacher from the `attachment_field` helper, but this won't work in the future, because we won't have an instance of the record we're trying to build. With this PR we only use AttachmentDefinition for which we only need the class, and not an instance of it.

The disadvantage of this PR is that the naming is all screwed up. AttachmentDefinition is a pretty terrible name, IMO. As is Attacher really. Can we come up with better names for this stuff?