### PR TITLE
Fix uploading large files to S3 via remote_url method

### DIFF
--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -102,6 +102,7 @@ module Refile
           content_type: response.headers[:content_type]
         }
         if valid?
+          response.file.open if response.file.closed? # https://github.com/refile/refile/pull/210
           @metadata[:id] = cache.upload(response.file).id
           write_metadata
         elsif @raise_errors


### PR DESCRIPTION
When I was trying to upload large image like [this one](https://markrahrens.files.wordpress.com/2014/03/dsc_1295.jpg).
I see this error IOError: closed stream

![screenshot from 2015-04-28 16 18 04](https://cloud.githubusercontent.com/assets/3481507/7370551/900abe14-edc3-11e4-80f5-67d83c2d91d6.png)

Somehow RestClient return closed file when uploaded files are large ( ~ from 15 MB)
And S3 wants this file to be opened
