### PR TITLE
[WIP] Add HEAD support and respond with ETag and Last-Modified headers

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 if Refile.automount
   Rails.application.routes.draw do
-    mount Refile.app, at: Refile.mount_point, as: :refile_app
+    mount Refile.app, at: Refile.mount_point, as: :refile_app, via: [:get, :post, :head, :options]
   end
 end

--- a/lib/refile/backend/file_system.rb
+++ b/lib/refile/backend/file_system.rb
@@ -92,6 +92,22 @@ module Refile
         ::File.exist?(path(id))
       end
 
+      # Return eTag of the file
+      #
+      # @param [Sring] id           The id of the file
+      # @return [String]
+      verify_id def etag(id)
+        Digest::MD5.file(path(id)).hexdigest
+      end
+
+      # Return last modified time of the file
+      #
+      # @param [Sring] id           The id of the file
+      # @return [Time]
+      verify_id def last_modified(id)
+        open(id).mtime
+      end
+
       # Remove all files in this backend. You must confirm the deletion by
       # passing the symbol `:confirm` as an argument to this method.
       #

--- a/lib/refile/backend/s3.rb
+++ b/lib/refile/backend/s3.rb
@@ -115,6 +115,22 @@ module Refile
         object(id).exists?
       end
 
+      # Return eTag of the file
+      #
+      # @param [Sring] id           The id of the file
+      # @return [String]
+      verify_id def etag(id)
+        object(id).etag.gsub('"', '')
+      end
+
+      # Return last modified time of the file
+      #
+      # @param [Sring] id           The id of the file
+      # @return [Time]
+      verify_id def last_modified(id)
+        object(id).last_modified
+      end
+
       # Remove all files in this backend. You must confirm the deletion by
       # passing the symbol `:confirm` as an argument to this method.
       #

--- a/lib/refile/file.rb
+++ b/lib/refile/file.rb
@@ -53,6 +53,16 @@ module Refile
       backend.exists?(id)
     end
 
+    # @return [String] the eTag of the file
+    def etag
+      backend.etag(id)
+    end
+
+    # @return [Time] last modified time of the file
+    def last_modified
+      backend.last_modified(id)
+    end
+
     # @return [IO] an IO object which contains the contents of the file
     def to_io
       io


### PR DESCRIPTION
Fixes #67
This still needs some touching (tests for the headers) but I would like some feedback. Thanks

Changes:
- [rails] mounting routes without :via it seems it doesn't catched HEAD requests; can't find the exact cause but probably something related to the rails router and `Rack::Head`
- added ETag and Last-Modified headers; other storage adapters will have some issues with this; probably if the adapter doesn't respond to the method we should read the file and calculate the ETag
- if it's a HEAD request halt as HEAD doesn't expects a reponse body

TODO: