### PR TITLE
fix attachment_tag no longer having cdn host

### DIFF
--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -36,7 +36,7 @@ module Refile
     # @param [Hash] options                      Additional options for the image tag
     # @see #attachment_url
     # @return [ActiveSupport::SafeBuffer, nil]   The generated image tag
-    def attachment_image_tag(record, name, *args, fallback: nil, format: nil, host: nil, **options)
+    def attachment_image_tag(record, name, *args, fallback: nil, format: nil, host: Refile.host, **options)
       file = record && record.public_send(name)
       classes = ["attachment", (record.class.model_name.singular if record), name, *options[:class]]
 

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -1,0 +1,46 @@
+require "refile/rails/attachment_helper"
+require "refile/active_record_helper"
+require "refile/attachment/active_record"
+require "action_view"
+
+describe Refile::AttachmentHelper do
+  include Refile::AttachmentHelper
+  include ActionView::Helpers::AssetTagHelper
+
+  let(:klass) do
+    Class.new(ActiveRecord::Base) do
+      self.table_name = :posts
+
+      def self.name
+        "Post"
+      end
+
+      attachment :document
+    end
+  end
+  let(:attachment_path) { "/attachments/00cc2633d08c6045485f1fae2cd6d4de20a5a159/store/xxx/document" }
+
+  def with_setting(key, value)
+    old = Refile.send(key)
+    Refile.send("#{key}=", value)
+    yield
+  ensure
+    Refile.send("#{key}=", old)
+  end
+
+  around { |example| with_setting(:secret_key, "xxxxxxxxxxx", &example) }
+
+  describe "#attachment_image_tag" do
+    let(:src) { attachment_image_tag(klass.new(document_id: "xxx"), :document)[/src="(\S+)"/, 1] }
+
+    it "builds with path" do
+      with_setting :host, nil do
+        expect(src).to eq attachment_path
+      end
+    end
+
+    it "builds with host" do
+      expect(src).to eq "//localhost:56120#{attachment_path}"
+    end
+  end
+end

--- a/spec/refile/spec_helper.rb
+++ b/spec/refile/spec_helper.rb
@@ -24,6 +24,10 @@ Refile.backends["limited_cache"] = FakePresignBackend.new(File.expand_path("defa
 
 Refile.direct_upload = %w[cache limited_cache]
 
+Refile.allow_origin = "*"
+
+Refile.host = "//localhost:56120"
+
 Refile.processor(:reverse) do |file|
   StringIO.new(file.read.reverse)
 end

--- a/spec/refile/test_app.rb
+++ b/spec/refile/test_app.rb
@@ -47,9 +47,6 @@ Capybara.configure do |config|
   config.server_port = 56_120
 end
 
-Refile.allow_origin = "*"
-Refile.host = "//localhost:56120"
-
 module TestAppHelpers
   def download_link(text)
     url = find_link(text)[:href]


### PR DESCRIPTION
https://github.com/refile/refile/commit/acb99c2f42efa596b9f2d9a3a5f124b5c2df049a

introduced a bug where attachment_tag would previously pass down nil to
attachment_url, but now this is no longer overwritten as Refile.host

also included a failing test :)

@jnicklas 