### PR TITLE
Fix Refile::VERSION to match the release (0.5.4)

### DIFF
--- a/lib/refile/version.rb
+++ b/lib/refile/version.rb
@@ -1,3 +1,3 @@
 module Refile
-  VERSION = "0.5.3"
+  VERSION = "0.5.4"
 end


### PR DESCRIPTION
I don't know if it makes sense to merge this at this point, but opened a PR anyway to remind that the version constant is lagging behind the released version.