### PR TITLE
Find metadata field even when file field is wrapped in error div

### DIFF
--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -26,7 +26,8 @@
     if(input.tagName === "INPUT" && input.type === "file" && input.getAttribute("data-direct")) {
       if(!input.files) { return; } // IE9, bail out if file API is not supported.
 
-      var metadataField = input.previousSibling;
+      var reference = input.getAttribute("data-reference");
+      var metadataField = document.querySelector("input[type=hidden][data-reference='" + reference + "']");
 
       var url = input.getAttribute("data-url");
       var fields = JSON.parse(input.getAttribute("data-fields") || "null");

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -79,8 +79,15 @@ module Refile
         options[:data].merge!(direct: true, presigned: true, url: url)
       end
 
-      html = hidden_field(object_name, method, multiple: options[:multiple], value: object.send("#{method}_data").to_json, object: object, id: nil)
-      html + file_field(object_name, method, options)
+      options[:data][:reference] = SecureRandom.hex
+
+      hidden_field(object_name, method,
+        multiple: options[:multiple],
+        value: object.send("#{method}_data").to_json,
+        object: object,
+        id: nil,
+        data: { reference: options[:data][:reference] }
+      ) + file_field(object_name, method, options)
     end
   end
 end

--- a/spec/refile/features/direct_upload_spec.rb
+++ b/spec/refile/features/direct_upload_spec.rb
@@ -28,6 +28,23 @@ feature "Direct HTTP post file uploads", :js do
     expect(page).to have_content("Upload failure error")
   end
 
+  scenario "Upload a file after validation failure" do
+    visit "/direct/posts/new"
+    fill_in "Title", with: "A cool post"
+    check "Requires document"
+    click_button "Create"
+
+    attach_file "Document", path("hello.txt")
+
+    expect(page).to have_content("Upload started")
+    expect(page).to have_content("Upload success")
+    expect(page).to have_content("Upload complete")
+
+    click_button "Create"
+
+    expect(download_link("Document")).to eq("hello")
+  end
+
   scenario "Fail to upload a file that has wrong format" do
     visit "/direct/posts/new"
     fill_in "Title", with: "A cool post"

--- a/spec/refile/test_app/app/controllers/direct_posts_controller.rb
+++ b/spec/refile/test_app/app/controllers/direct_posts_controller.rb
@@ -4,7 +4,7 @@ class DirectPostsController < ApplicationController
   end
 
   def create
-    @post = Post.new(params.require(:post).permit(:title, :document, :image, documents_files: []))
+    @post = Post.new(params.require(:post).permit(:title, :document, :image, :requires_document, documents_files: []))
 
     if @post.save
       redirect_to [:normal, @post]

--- a/spec/refile/test_app/app/models/post.rb
+++ b/spec/refile/test_app/app/models/post.rb
@@ -1,8 +1,18 @@
 class Post < ActiveRecord::Base
+  attr_accessor :requires_document
+
   attachment :image, type: :image
   attachment :document, cache: :limited_cache
   validates_presence_of :title
 
   has_many :documents
   accepts_attachments_for :documents
+
+  validates_presence_of :document, if: :requires_document?
+
+private
+
+  def requires_document?
+    !requires_document.to_i.zero?
+  end
 end

--- a/spec/refile/test_app/app/views/direct_posts/new.html.erb
+++ b/spec/refile/test_app/app/views/direct_posts/new.html.erb
@@ -19,6 +19,10 @@
     <%= form.attachment_field :image, direct: true %>
   </p>
   <p>
+    <%= form.label :requires_document %>
+    <%= form.check_box :requires_document %>
+  </p>
+  <p>
     <%= form.submit "Create" %>
   </p>
 <% end %>


### PR DESCRIPTION
This isn't a particularly elegant solution, but I couldn't come up with any other way of ensuring that the fields can refer to each other.