### PR TITLE
Add instructions to README for using Refile in Rails Engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,24 @@ end
 Refile will now fetch the file from the given URL, following redirects if
 needed.
 
+## Using Refile inside of Rails Engines
+
+If you want to use Refile inside of a Rails Engine you need to load it the folloing way:
+
+``` ruby
+# gemspec of Rails Engine
+s.add_dependency 'mini_magick'
+s.add_dependency 'refile'
+s.add_dependency 'refile-mini_magick'
+```
+
+``` ruby
+# lib file of Rails Engine
+require 'mini_magick'
+require 'refile/rails'
+require 'refile/mini_magick'
+```
+
 ## Cache expiry
 
 Files will accumulate in your cache, and you'll probably want to remove them


### PR DESCRIPTION
I wanted to use Refile in a Rails Engine and ran into the problem, that I wanted to require `refile-mini_magick`. This lead to the following error which confused me a lot:

```
bin/rails:6: warning: already initialized constant APP_PATH
```

The only error was the wrong required file, so maybe this might help someone in the future.