### PR TITLE
when available, use mime/types/columnar which is more memory efficient

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -3,7 +3,14 @@ require "fileutils"
 require "tempfile"
 require "rest_client"
 require "logger"
-require "mime/types"
+
+begin
+
+  # Use mime/types/columnar if available, for reduced memory usage
+  require "mime/types/columnar"
+rescue LoadError
+  require "mime/types"
+end
 
 module Refile
   # @api private


### PR DESCRIPTION
I stumbled upon [this PR](https://github.com/thoughtbot/paperclip/pull/1873) on paperclip, by @schneems, and I thought that refile could use the change as well.

Looks like a decent amount of memory could be saved by using the Columnar version of mime-types when available, with little to no changes.

The changes on this PR were shamelessly taken from similar PRs by @jeremyevans (mikel/mail#880) & @schneems (thoughtbot/paperclip#1873)

- see: https://github.com/mime-types/ruby-mime-types/pull/96