### PR TITLE
Remove mini_magick Gemfile line in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Sponsored by:
 Add the gem:
 
 ``` ruby
-gem "mini_magick"
 gem "refile", require: "refile/rails"
 gem "refile-mini_magick"
 ```


### PR DESCRIPTION
`refile-mini_magick` already has `mini_magick` as a dependency.