### PR TITLE
ship less files and simplify gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,6 @@ Lint/DefEndAlignment:
 
 Lint/HandleExceptions:
   Enabled: false
+
+Style/SpecialGlobalVars:
+  Enabled: false

--- a/refile.gemspec
+++ b/refile.gemspec
@@ -1,7 +1,4 @@
-# coding: utf-8
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "refile/version"
+require "./lib/refile/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "refile"
@@ -12,10 +9,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/refile/refile"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
-  spec.require_paths = %w[lib spec]
+  spec.files         = `git ls-files lib spec Readme.md`.split($/).reject { |f| f.include?("test_app") }
+  spec.require_paths = %w[lib spec] # spec is used by backend gems to run their tests
 
   spec.required_ruby_version = ">= 2.1.0"
 


### PR DESCRIPTION
@jnicklas 

shipping a bunch of test / misc files means download takes longer and vendor/cache gets bigger

adding spec to require-path means the spec files are actually in the gems load path ... but they are not supposed to be required ... right ?

also removing LOAD_PATH modifications 