### PR TITLE
List refile-mongoid as an ORM gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ integrate with any ORM, so building your own should not be too difficult. Some
 integrations are already available via gems:
 
 * [refile-sequel](https://github.com/refile/refile-sequel)
+* [refile-mongoid](https://github.com/krettan/refile-mongoid)
 
 ### Pure Ruby classes
 


### PR DESCRIPTION
List the [refile-mongoid](https://github.com/krettan/refile-mongoid) extension which implements the `Refile::Mongoid::Attachment` under "Other ORMs".

_Background:_ To use refile in a rails application with mongoid and no ActiveRecord, a gem like [refile-sequel](https://github.com/refile/refile-sequel) is needed. Looked like there was none, so I took the liberty of writing one. It's basically a clone of [refile-sequel](https://github.com/refile/refile-sequel) but using mongo instead.