### PR TITLE
Fix attachment extension validation when extension is in randomcase

### DIFF
--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -37,7 +37,8 @@ module Refile
 
     def validate(attacher)
       errors = []
-      errors << :invalid_extension if valid_extensions and not valid_extensions.include?(attacher.extension)
+      extension_included = valid_extensions && valid_extensions.map(&:downcase).include?(attacher.extension.downcase)
+      errors << :invalid_extension if valid_extensions and not extension_included
       errors << :invalid_content_type if valid_content_types and not valid_content_types.include?(attacher.content_type)
       errors << :too_large if cache.max_size and attacher.size and attacher.size >= cache.max_size
       errors

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -19,6 +19,59 @@ describe Refile::ActiveRecord::Attachment do
   describe "#valid?" do
     let(:options) { { type: :image, cache: :limited_cache } }
 
+    context "extension validation" do
+      let(:options) { { cache: :limited_cache, extension: %w(Png) } }
+
+      context "with file" do
+        it "returns true when extension is included in list" do
+          post = klass.new
+          post.document = Refile::FileDouble.new("hello", "image.Png")
+          expect(post.valid?).to be_truthy
+          expect(post.errors[:document]).to be_empty
+        end
+
+        it "returns true when extension is included in list but chars are randomcase" do
+          post = klass.new
+          post.document = Refile::FileDouble.new("hello", "image.PNG")
+          expect(post.valid?).to be_truthy
+          expect(post.errors[:document]).to be_empty
+        end
+
+        it "returns false when extension is invalid" do
+          post = klass.new
+          post.document = Refile::FileDouble.new("hello", "image.jpg")
+          expect(post.valid?).to be_falsy
+          expect(post.errors[:document].length).to eq(1)
+        end
+      end
+
+      context "with metadata" do
+        it "returns true when extension is included in list" do
+          file = Refile.cache.upload(StringIO.new("hello"))
+          post = klass.new
+          post.document = { id: file.id, filename: "image.Png" }.to_json
+          expect(post.valid?).to be_truthy
+          expect(post.errors[:document]).to be_empty
+        end
+
+        it "returns true when extension is included in list but chars are randomcase" do
+          file = Refile.cache.upload(StringIO.new("hello"))
+          post = klass.new
+          post.document = { id: file.id, filename: "image.PNG" }.to_json
+          expect(post.valid?).to be_truthy
+          expect(post.errors[:document]).to be_empty
+        end
+
+        it "returns false when extension is invalid" do
+          file = Refile.cache.upload(StringIO.new("hello"))
+          post = klass.new
+          post.document = { id: file.id, filename: "image.jpg" }.to_json
+          expect(post.valid?).to be_falsy
+          expect(post.errors[:document].length).to eq(1)
+        end
+      end
+    end
+
     context "with file" do
       it "returns true when no file is assigned" do
         post = klass.new


### PR DESCRIPTION
I found a bug when uploaded file extension name is randomcased. (Iphone creates movies with MOV format for example). And app hasn't content type validation, only extensions list.
I wrote some tests and fixed invalid behaviour.