### PR TITLE
make the default instructions the same region as the previous default…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ require "refile/s3"
 aws = {
   access_key_id: "xyz",
   secret_access_key: "abc",
-  region: "sa-east-1",
+  region: "us-west-2",
   bucket: "my-bucket",
 }
 Refile.cache = Refile::S3.new(prefix: "cache", **aws)


### PR DESCRIPTION
… so images stay visible

previously the default region was used us-west-2
when upgrading all my images were gone because I did not know what region my bucket was in
I was able to find it via `Refile.store.instance_variable_get(:@bucket).location_constraint` but that took me some digging ...

@jnicklas 