### PR TITLE
Fix Encoding::UndefinedConversionError during upload (Related to #187)

### DIFF
--- a/lib/refile/backend/file_system.rb
+++ b/lib/refile/backend/file_system.rb
@@ -34,7 +34,7 @@ module Refile
       # @return [Refile::File]      The uploaded file
       verify_uploadable def upload(uploadable)
         id = @hasher.hash(uploadable)
-        IO.copy_stream(uploadable, path(id))
+        ::File.open(path(id), "wb") { |dest| IO.copy_stream(uploadable, dest) }
 
         Refile::File.new(self, id)
       end

--- a/spec/refile/backend_examples.rb
+++ b/spec/refile/backend_examples.rb
@@ -33,7 +33,7 @@ RSpec.shared_examples_for :backend do
       expect(retrieved.exists?).to be_truthy
     end
 
-    context 'when Encoding.default_internal is set to UTF-8' do
+    context "when Encoding.default_internal is set to UTF-8" do
       let(:binary) { "\x89PNG\r\n\x1A\n\x00\x00".force_encoding("ASCII-8BIT") }
       let(:binary_file) { uploadable(binary) }
 

--- a/spec/refile/backend_examples.rb
+++ b/spec/refile/backend_examples.rb
@@ -32,6 +32,29 @@ RSpec.shared_examples_for :backend do
       expect(retrieved.size).to eq(5)
       expect(retrieved.exists?).to be_truthy
     end
+
+    context 'when Encoding.default_internal is set to UTF-8' do
+      let(:binary) { "\x89PNG\r\n\x1A\n\x00\x00".force_encoding("ASCII-8BIT") }
+      let(:binary_file) { uploadable(binary) }
+
+      before do
+        @encoding_before = Encoding.default_internal
+        Encoding.default_internal = Encoding::UTF_8
+      end
+      after do
+        Encoding.default_internal = @encoding_before
+      end
+
+      it "can store an uploaded file binary file" do
+        file = backend.upload(binary_file)
+        file2 = backend.upload(file)
+
+        retrieved = backend.get(file2.id)
+
+        expect(retrieved.size).to eq(10)
+        expect(retrieved.exists?).to be_truthy
+      end
+    end
   end
 
   describe "#delete" do


### PR DESCRIPTION
When you try to upload a binary file using jruby, it raises Encoding::UndefinedConversionError.

In related #187 issue @janko-m determined that it only happens when you use a wrapper around an IO (e.g. Refile::File).

I've found out that it happens due to `Encoding.default_internal = Encoding::UTF_8` line in rails internals.
see: https://github.com/jruby/jruby/issues/2779#issuecomment-113473546 for details

In this PR, I tried to workaround the issue by directly opening destination file with binary mode during upload.
It should make it clear for `IO.copy_stream` that dest file is in binary, ascii-8bit encoding and it doesn't need to convert the content of uploadable file to default internal encoding (which is UTF_8) prior to writing it to the destination.

I tested it with jruby-9.0.0.0.rc1.