### PR TITLE
Remove unnecessary instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,6 @@ Refile.cache = Refile::S3.new(prefix: "cache", **aws)
 Refile.store = Refile::S3.new(prefix: "store", **aws)
 ```
 
-And add to your Gemfile:
-```ruby
-gem "aws-sdk"
-```
-
 Try this in the quick start example above and your files are now uploaded to
 S3.
 


### PR DESCRIPTION
It isn't needed to add the `aws-sdk` gem since it is a dependency of the `refile-s3` gem.
`https://github.com/refile/refile-s3/blob/master/refile-s3.gemspec#L21`