### PR TITLE
Prevent AJAX caching errors

### DIFF
--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -63,6 +63,7 @@
         if(input.getAttribute("data-presigned")) {
           dispatchEvent(input, "presign:start");
           var presignXhr = new XMLHttpRequest();
+          var presignUrl = url + "?t=" + Date.now() + "." + index;
           presignXhr.addEventListener("load", function() {
             dispatchEvent(input, "presign:complete");
             if(isSuccess(presignXhr)) {
@@ -77,7 +78,7 @@
               xhr.complete = true;
             };
           });
-          presignXhr.open("GET", url, true);
+          presignXhr.open("GET", presignUrl, true);
           presignXhr.send();
         } else {
           xhr.open("POST", url, true);


### PR DESCRIPTION
When using the multiple files feature on Safari (8.0.7 / OS X 10.10.4), sometimes the response to the presign url is cached resulting in the same upload id for multiple files, which in turn results in multiple files overwriting the same cached file.
This change fixes the issue by adding a querystring parameter to the presign url consisting of a timestamp and the file index, therefore avoiding duplicate urls.