### PR TITLE
add fallback option to attachment_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,10 +369,11 @@ There's also a helper for generating image tags:
 <%= attachment_image_tag(@user, :profile_image, :fill, 300, 300) %>
 ```
 
-With this helper you can specify an image which is used as a fallback in case
+With this helper you can specify an image/asset which is used as a fallback in case
 no file has been uploaded:
 
 ``` erb
+<%= attachment_url(@user, :profile_image, :fill, 300, 300, fallback: "default.png") %>
 <%= attachment_image_tag(@user, :profile_image, :fill, 300, 300, fallback: "default.png") %>
 ```
 

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -19,11 +19,17 @@ module Refile
     # @param [Refile::Attachment] object   Instance of a class which has an attached file
     # @param [Symbol] name                 The name of the attachment column
     # @param [String, nil] filename        The filename to be appended to the URL
+    # @param [String, nil] fallback        The path to an asset to be used as a fallback
     # @param [String, nil] format          A file extension to be appended to the URL
     # @param [String, nil] host            Override the host
     # @return [String, nil]                The generated URL
-    def attachment_url(record, name, *args, **opts)
-      Refile.attachment_url(record, name, *args, **opts)
+    def attachment_url(record, name, *args, fallback: nil, **opts)
+      file = record && record.public_send(name)
+      if file
+        Refile.attachment_url(record, name, *args, **opts)
+      elsif fallback
+        asset_url(fallback)
+      end
     end
 
     # Generates an image tag for the given attachment, adding appropriate


### PR DESCRIPTION
Say one wants to use HTML5's srcset for [responsive image](http://demosthenes.info/blog/944/Responsive-Images-For-Retina-Using-HTML5s-srcset) display. To do that, multiple urls needs to be generated for different devices. `attachment_url` is perfect for this job except that it doesn't have any fallback option as is available in `attachment_image_tag`. This PR adds that option.

The fallback functionality could have been delegated from `attachment_image_tag` to `attachment_url` like this:
```ruby
def attachment_image_tag(record, name, *args, fallback: nil, format: nil, host: Refile.host, **options)
  classes = ["attachment", (record.class.model_name.singular if record), name, *options[:class]]
  image_tag(attachment_url(record, name, *args, fallback: fallback, format: format, host: host), options.merge(class: classes))
end
```
But the current method adds 'fallback' class to the fallback image_tag which I think is a good feature. So I didn't touch `attachment_image_tag`.