### PR TITLE
The `attachment_field` generates the right `data-url` when has `default_url_options`

### DIFF
--- a/History.md
+++ b/History.md
@@ -3,6 +3,7 @@
 Unreleased
 
 - [BREAKING] `Refile.direct_upload` has been renamed to `Refile.allow_uploads_to`.
+- [FIXED] `attachment_field` generates the right `data-url` when has `default_url_options`
 
 # 0.5.5
 

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -68,14 +68,15 @@ module Refile
 
       host = options[:host] || Refile.host || request.base_url
       backend_name = Refile.backends.key(definition.cache)
+      refile_app_path = URI(main_app.refile_app_path).path
 
       if options[:direct]
-        url = ::File.join(host, main_app.refile_app_path, backend_name)
+        url = ::File.join(host, refile_app_path, backend_name)
         options[:data].merge!(direct: true, as: "file", url: url)
       end
 
       if options[:presigned] and definition.cache.respond_to?(:presign)
-        url = ::File.join(host, main_app.refile_app_path, backend_name, "presign")
+        url = ::File.join(host, refile_app_path, backend_name, "presign")
         options[:data].merge!(direct: true, presigned: true, url: url)
       end
 

--- a/spec/refile/test_app/app/controllers/application_controller.rb
+++ b/spec/refile/test_app/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  def default_url_options(_options = {})
+    { locale: I18n.locale }
+  end
 end


### PR DESCRIPTION
When we haved defined a `default_url_options` on a controller and use the
`attachment_field` to send a direct upload, the generated `data-url` attribute
has a invalid url like
`http://localhost:56120/attachments?locale=en/limited_cache` leading to errors.

This patch removes all query string params returning only the path of the
`refile_app_path`. Returning a url like
`http://localhost:56120/attachments/limited_cache`.

I not added any new test, since if we change the `attachment_field` to the old behavior with the `default_url_options` the following specs will broken because of the invalid url:

```
rspec ./spec/refile/features/direct_upload_spec.rb:4 # Direct HTTP post file uploads Successfully upload a file
rspec ./spec/refile/features/direct_upload_spec.rb:23 # Direct HTTP post file uploads Fail to upload a file that is too large
rspec ./spec/refile/features/direct_upload_spec.rb:32 # Direct HTTP post file uploads Upload a file after validation failure
rspec ./spec/refile/features/direct_upload_spec.rb:49 # Direct HTTP post file uploads Fail to upload a file that has wrong format
rspec ./spec/refile/features/multiple_upload_spec.rb:75 # Multiple file uploads with direct upload Successfully upload a file
rspec ./spec/refile/features/multiple_upload_spec.rb:93 # Multiple file uploads with presigned upload Successfully upload a file
rspec ./spec/refile/features/multiple_upload_spec.rb:111 # Multiple file uploads with presigned upload Fail to upload a file that is too large
rspec ./spec/refile/features/presigned_upload_spec.rb:4 # Direct HTTP post file uploads Successfully upload a file
rspec ./spec/refile/features/presigned_upload_spec.rb:21 # Direct HTTP post file uploads Fail to upload a file that is too large
```

I am not sure, but I think this PR closes the https://github.com/refile/refile/issues/306.