### PR TITLE
Added support for receiving parsed json instead of just raw json strings

### DIFF
--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -71,7 +71,7 @@ module Refile
     end
 
     def set(value)
-      if value.is_a?(String)
+      if value.is_a?(String) or value.is_a?(Hash)
         retrieve!(value)
       else
         cache!(value)
@@ -79,7 +79,11 @@ module Refile
     end
 
     def retrieve!(value)
-      @metadata = Refile.parse_json(value, symbolize_names: true) || {}
+      if value.is_a?(String)
+        @metadata = Refile.parse_json(value, symbolize_names: true) || {}
+      elsif value.is_a?(Hash)
+        @metadata = value
+      end
       write_metadata if cache_id
     end
 

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -42,6 +42,21 @@ describe Refile::Attachment do
       expect(instance.document_content_type).to eq("text/plain")
     end
 
+    it "receives parsed data and retrieves file from it" do
+      file = Refile.cache.upload(Refile::FileDouble.new("hello"))
+      instance.document = { id: file.id, filename: "foo.txt", content_type: "text/plain", size: 5 }
+
+      expect(instance.document.read).to eq("hello")
+
+      expect(instance.document_attacher.data[:filename]).to eq("foo.txt")
+      expect(instance.document_attacher.data[:size]).to eq(5)
+      expect(instance.document_attacher.data[:content_type]).to eq("text/plain")
+
+      expect(instance.document_filename).to eq("foo.txt")
+      expect(instance.document_size).to eq(5)
+      expect(instance.document_content_type).to eq("text/plain")
+    end
+
     it "does nothing when assigned string lacks an id" do
       instance.document = { size: 5 }.to_json
 


### PR DESCRIPTION
We have some javascript that sends a POST request to Rails containing some metadata about a file pre-uploaded to S3 using the refile-s3 gem. The sent data follows the expected JSON format for Refile, but a gem we're using (JSONAPI::Resources) automatically parses that JSON.

The existing Refile code would assume that the data would be a Refile::File. This PR changes that behavior so that it can be smart about pre-parsed JSON.