### PR TITLE
ensures that upload:complete is dispatched after upload:success or upload:failure

### DIFF
--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -48,12 +48,12 @@
           if(requests.every(function(xhr) { return xhr.complete })) {
             finalizeUpload();
           }
-          dispatchEvent(input, "upload:complete");
           if(isSuccess(xhr)) {
             dispatchEvent(input, "upload:success");
           } else {
             dispatchEvent(input, "upload:failure");
           }
+          dispatchEvent(input, "upload:complete");
         });
 
         xhr.upload.addEventListener("progress", function(progressEvent) {


### PR DESCRIPTION
`upload:complete` is being dispatched before `upload:success` or `upload:failure`. I believe this is a bug. I want to track failed uploads and the order of events makes that tricky. I've redacted much of the code for brevity, but it should provide an idea.

```coffeescript
class App.NewUpload
  errors: []

  template: (index, filename) ->
    """
      <tr data-upload="#{index}">
        <td>#{filename}</td>
      </tr>
    """

  constructor: (@form) ->
    @setEvents()

  setEvents: ->
    $(document).on 'upload:failure', @form, (event) =>
      @handleFailure event.originalEvent.detail
    $(document).on 'upload:complete', @form, @handleComplete

  handleFailure: (detail) =>
    upload = @findUpload detail.index
    @errors.push upload

  handleComplete: =>
    unless @form.find('input.uploading').length
      if @errors.length
        @toggleNotice 'Warning'
      else
        @toggleNotice 'Success'
```
Because `failure` and `success` are fired before `complete`,  with only one upload, we can not track the outcome because `@errors.length` would be 0.