### PR TITLE
Adds soft_delete configuration option

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -94,6 +94,13 @@ module Refile
     # @return [String]
     attr_accessor :secret_key
 
+    # Should we keep files after a record is deleted?
+    #
+    # The default is false.
+    #
+    # @return [Boolean]
+    attr_accessor :soft_delete
+
     # A global registry of backends.
     #
     # @return [Hash{String => Backend}]
@@ -369,4 +376,5 @@ Refile.configure do |config|
   config.automount = true
   config.content_max_age = 60 * 60 * 24 * 365
   config.types[:image] = Refile::Type.new(:image, content_type: %w[image/jpeg image/gif image/png])
+  config.soft_delete = false
 end

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -42,7 +42,9 @@ module Refile
         end
 
         after_destroy do
-          send(attacher).delete!
+          unless Refile.soft_delete
+            send(attacher).delete!
+          end
         end
       end
 

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -162,6 +162,16 @@ describe Refile::ActiveRecord::Attachment do
       post.destroy
       expect(file.exists?).to be_falsy
     end
+
+    it "keeps the stored file if soft_delete is enabled" do
+      Refile.soft_delete = true
+      post = klass.new
+      post.document = Refile::FileDouble.new("hello")
+      post.save
+      file = post.document
+      post.destroy
+      expect(file.exists?).to be_truthy
+    end
   end
 
   describe ".accepts_nested_attributes_for" do


### PR DESCRIPTION
@jnicklas I don't expect this to get merged, but I would like your feedback so I can improve the feature. I added a config option to `refile.rb` called `soft_delete`; it defaults to `false`. I check for this option before running line https://github.com/refile/refile/blob/master/lib/refile/attachment/active_record.rb#L44, when then `after_delete` callback executes. See issue #309 for reference.

Some feedback would be nice...

1. It feels wrong to add `soft_delete` to the config when it only works with ActiveRecord. It seems like `soft_delete` should work regardless of the adapter. The only other place I can think of implementing this is https://github.com/refile/refile/blob/master/lib/refile/attacher.rb#L134. Perhaps I'm wrong.
2. Should there be more tests? For example, that `soft_delete` defaults to `false` and that it can be set? Where would we add those? `refile_spec.rb`?
3. Is the one test in `spec/refile/attachment/active_record_spec.rb` sufficient for this feature?
4. Is `soft_delete` a good name?