### PR TITLE
updates quickstart to include all necessary migration fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ end
 Generate a migration:
 
 ``` sh
-rails generate migration add_profile_image_to_users profile_image_id:string
+rails generate migration add_profile_image_to_users profile_image_id:string &&
+profile_image_filename:string && profile_image_content_size:string &&
+profile_image_content_type:string
+
 rake db:migrate
 ```
 


### PR DESCRIPTION
The current quickstart guide neglects to include necessary fields. If the quickstart were followed precisely, it results in an error.
