### PR TITLE
Better support for validating presence of attachment

### DIFF
--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -74,9 +74,9 @@ module Refile
 
     def set(value)
       case value
-      when nil then self.remove = true
-      when String, Hash then retrieve!(value)
-      else cache!(value)
+        when nil then self.remove = true
+        when String, Hash then retrieve!(value)
+        else cache!(value)
       end
     end
 

--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -63,7 +63,9 @@ module Refile
     end
 
     def get
-      if cache_id
+      if remove?
+        nil
+      elsif cache_id
         cache.get(cache_id)
       elsif id
         store.get(id)
@@ -71,10 +73,10 @@ module Refile
     end
 
     def set(value)
-      if value.is_a?(String) or value.is_a?(Hash)
-        retrieve!(value)
-      else
-        cache!(value)
+      case value
+      when nil then self.remove = true
+      when String, Hash then retrieve!(value)
+      else cache!(value)
       end
     end
 

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -102,7 +102,6 @@ describe Refile::ActiveRecord::Attachment do
         expect(post.valid?).to be_truthy
         expect(post.errors[:document]).to be_empty
       end
-
     end
 
     context "when file is required" do

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -3,8 +3,10 @@ require "refile/attachment/active_record"
 
 describe Refile::ActiveRecord::Attachment do
   let(:options) { {} }
+  let(:required) { false }
   let(:klass) do
     opts = options
+    req = required
     Class.new(ActiveRecord::Base) do
       self.table_name = :posts
 
@@ -13,6 +15,7 @@ describe Refile::ActiveRecord::Attachment do
       end
 
       attachment :document, **opts
+      validates_presence_of :document, if: -> { req }
     end
   end
 
@@ -98,6 +101,30 @@ describe Refile::ActiveRecord::Attachment do
         post.document = Refile::FileDouble.new("hello", content_type: "image/png")
         expect(post.valid?).to be_truthy
         expect(post.errors[:document]).to be_empty
+      end
+
+    end
+
+    context "when file is required" do
+      let(:required) { true }
+      let(:options) { {} }
+
+      it "returns false without file" do
+        post = klass.new
+        expect(post.valid?).to be_falsy
+      end
+
+      it "returns true with file" do
+        post = klass.new
+        post.document = Refile::FileDouble.new("hello", "image.png")
+        expect(post.valid?).to be_truthy
+      end
+
+      it "returns false when nil is assigned after a file" do
+        post = klass.new
+        post.document = Refile::FileDouble.new("hello", "image.png")
+        post.document = nil
+        expect(post.valid?).to be_falsy
       end
     end
 

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -70,6 +70,17 @@ describe Refile::Attachment do
       expect(instance.document).to be_nil
       expect(instance.document_size).to be_nil
     end
+
+    it "accepts nil" do
+      instance.document = nil
+      expect(instance.document).to be_nil
+    end
+
+    it "removes a document when assigned nil" do
+      instance.document = Refile::FileDouble.new("hello", "foo.txt", content_type: "text/plain")
+      instance.document = nil
+      expect(instance.document).to be_nil
+    end
   end
 
   describe ":name" do


### PR DESCRIPTION
As discussed in #355, to validates the presence of an attachment, you should be able to do
```ruby
class Attachment < ActiveRecord::Base
  attachment :file
  validates_presence_of :file
end
```

Setting `attachment.file = nil` raises the exception `undefined method 'size' for nil:NilClass`. This PR fixes this by making `attachment.file = nil` mean the same thing as `attachment.remove_file = true`.

Setting `attachment.file = nil` or `attachment.remove_file = true` will still return the old file in `attachment.file` so the validation passes even though the file will be removed after save. This PR returns `nil` for `attachment.file` if `attacher.remove? == true`.
