### PR TITLE
add presenter support for attachment_image_tag helper

### DIFF
--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -37,11 +37,12 @@ module Refile
     # @see #attachment_url
     # @return [ActiveSupport::SafeBuffer, nil]   The generated image tag
     def attachment_image_tag(record, name, *args, fallback: nil, format: nil, host: Refile.host, **options)
-      file = record && record.public_send(name)
-      classes = ["attachment", (record.class.model_name.singular if record), name, *options[:class]]
+      model = record && record.to_model
+      file = model && model.public_send(name)
+      classes = ["attachment", (model.class.model_name.singular if model), name, *options[:class]]
 
       if file
-        image_tag(attachment_url(record, name, *args, format: format, host: host), options.merge(class: classes))
+        image_tag(attachment_url(model, name, *args, format: format, host: host), options.merge(class: classes))
       elsif fallback
         classes << "fallback"
         image_tag(fallback, options.merge(class: classes))

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -43,4 +43,16 @@ describe Refile::AttachmentHelper do
       expect(src).to eq "http://localhost:56120#{attachment_path}"
     end
   end
+
+  context "with presenter" do
+    let(:presenter_class) { Class.new(SimpleDelegator) }
+    let(:model) { klass.new(document_id: "xxx") }
+    let(:presenter) { presenter_class.new model }
+
+    describe "#attachment_image_tag" do
+      it "work correct" do
+        expect{attachment_image_tag(presenter, :document)}.to_not raise_error(NoMethodError, /model_name/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I find solution for #334. It use `to_model` method and behaves in the same way in different versions of Rails.
