### PR TITLE
Adds `destroy: true | false` option to `attachment` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,19 @@ class User
 end
 ```
 
+### Keeping uploaded files
+
+By default Refile will delete a stored file when its model is destroyed. You can change this behaviour by passing in the `destroy` option.
+
+```ruby
+class User < ActiveRecord::Base
+  attachment :profile_image, destroy: false
+end
+
+```
+
+Now Refile will not delete the `profile_image` file from the store if the user is destroyed.
+
 ## 3. Rack Application
 
 Refile includes a Rack application (an endpoint, not a middleware), written in

--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -34,8 +34,9 @@ module Refile
     # @param [Symbol, nil] type                         The type of file that can be uploaded, see {Refile.types}
     # @param [String, Array<String>, nil] extension     Limit the uploaded file to the given extension or list of extensions
     # @param [String, Array<String>, nil] content_type  Limit the uploaded file to the given content type or list of content types
+    # @param [true, false] destroy                      Whether to remove stored file if its model is destroyed
     # @return [void]
-    def attachment(name, cache: :cache, store: :store, raise_errors: true, type: nil, extension: nil, content_type: nil)
+    def attachment(name, cache: :cache, store: :store, raise_errors: true, type: nil, extension: nil, content_type: nil, destroy: true)
       definition = AttachmentDefinition.new(name,
         cache: cache,
         store: store,

--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -34,9 +34,8 @@ module Refile
     # @param [Symbol, nil] type                         The type of file that can be uploaded, see {Refile.types}
     # @param [String, Array<String>, nil] extension     Limit the uploaded file to the given extension or list of extensions
     # @param [String, Array<String>, nil] content_type  Limit the uploaded file to the given content type or list of content types
-    # @param [true, false] destroy                      Whether to remove stored file if its model is destroyed
     # @return [void]
-    def attachment(name, cache: :cache, store: :store, raise_errors: true, type: nil, extension: nil, content_type: nil, destroy: true)
+    def attachment(name, cache: :cache, store: :store, raise_errors: true, type: nil, extension: nil, content_type: nil)
       definition = AttachmentDefinition.new(name,
         cache: cache,
         store: store,

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -5,10 +5,11 @@ module Refile
 
       # Attachment method which hooks into ActiveRecord models
       #
+      # @param [true, false] destroy  Whether to remove the stored file if its model is destroyed
       # @return [void]
       # @see Refile::Attachment#attachment
       def attachment(name, raise_errors: false, destroy: true, **options)
-        super
+        super(name, raise_errors: raise_errors, **options)
 
         attacher = "#{name}_attacher"
 

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -7,7 +7,7 @@ module Refile
       #
       # @return [void]
       # @see Refile::Attachment#attachment
-      def attachment(name, raise_errors: false, **options)
+      def attachment(name, raise_errors: false, destroy: true, **options)
         super
 
         attacher = "#{name}_attacher"
@@ -42,7 +42,7 @@ module Refile
         end
 
         after_destroy do
-          send(attacher).delete!
+          send(attacher).delete! if destroy
         end
       end
 

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -154,13 +154,41 @@ describe Refile::ActiveRecord::Attachment do
   end
 
   describe "#destroy" do
-    it "removes the stored file" do
-      post = klass.new
-      post.document = Refile::FileDouble.new("hello")
-      post.save
-      file = post.document
-      post.destroy
-      expect(file.exists?).to be_falsy
+    context "default behaviour" do
+      it "removes the stored file" do
+        post = klass.new
+        post.document = Refile::FileDouble.new("hello")
+        post.save
+        file = post.document
+        post.destroy
+        expect(file.exists?).to be_falsy
+      end
+    end
+
+    context "with destroy: true" do
+      let(:options) { { destroy: true } }
+
+      it "removes the stored file" do
+        post = klass.new
+        post.document = Refile::FileDouble.new("hello")
+        post.save
+        file = post.document
+        post.destroy
+        expect(file.exists?).to be_falsy
+      end
+    end
+
+    context "with destroy: false" do
+      let(:options) { { destroy: false } }
+
+      it "does not remove the stored file" do
+        post = klass.new
+        post.document = Refile::FileDouble.new("hello")
+        post.save
+        file = post.document
+        post.destroy
+        expect(file.exists?).to be_truthy
+      end
     end
   end
 


### PR DESCRIPTION
@jnicklas As discussed in #333 this adds a `destroy: true | false` option. It defaults to true. I'm unsure if the documentation is in the right place. Any feedback is welcome!