### PR TITLE
Make Refile::FileDouble available to gem users

### DIFF
--- a/lib/refile/file_double.rb
+++ b/lib/refile/file_double.rb
@@ -1,0 +1,13 @@
+module Refile
+  class FileDouble
+    attr_reader :original_filename, :content_type
+    def initialize(data, name = nil, content_type: nil)
+      @io = StringIO.new(data)
+      @original_filename = name
+      @content_type = content_type
+    end
+
+    extend Forwardable
+    def_delegators :@io, :read, :rewind, :size, :eof?, :close
+  end
+end

--- a/spec/refile/spec_helper.rb
+++ b/spec/refile/spec_helper.rb
@@ -3,6 +3,7 @@ ENV["RACK_ENV"] = "test"
 require "refile"
 require "refile/backend_examples"
 require "webmock/rspec"
+require "refile/file_double"
 
 tmp_path = Dir.mktmpdir
 
@@ -55,37 +56,6 @@ Refile.processor(:convert_case) do |file, options = {}|
     when "up" then StringIO.new(file.read.upcase)
     when "down" then StringIO.new(file.read.downcase)
     else file
-  end
-end
-
-module Refile
-  class FileDouble
-    attr_reader :original_filename, :content_type
-    def initialize(data, name = nil, content_type: nil)
-      @io = StringIO.new(data)
-      @original_filename = name
-      @content_type = content_type
-    end
-
-    def read(*args)
-      @io.read(*args)
-    end
-
-    def rewind
-      @io.rewind
-    end
-
-    def size
-      @io.size
-    end
-
-    def eof?
-      @io.eof?
-    end
-
-    def close
-      @io.close
-    end
   end
 end
 


### PR DESCRIPTION
When I write specs for my own models using Refile, I want an easy way to provide files. The easiest way is to use the Refile::FileDouble class, but currently it's hidden inside the spec helper.

This PR puts FileDouble in the lib directory so it is available to gem users.

If you like the idea I can add a small section to the README about testing your own classes.