### PR TITLE
Always return 304 Not Modified when the browser asks for updated file

### DIFF
--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -35,6 +35,7 @@ module Refile
     # This will match all token authenticated requests
     before "/:token/:backend/*" do
       halt 403 unless verified?
+      halt 304 if has_if_modified_since?
     end
 
     get "/:token/:backend/:id/:filename" do
@@ -90,6 +91,11 @@ module Refile
       "forbidden"
     end
 
+    error 304 do
+      content_type :text
+      "not modified"
+    end
+
     error Refile::InvalidFile do
       status 400
       "Upload failure error"
@@ -117,6 +123,10 @@ module Refile
 
     def upload_allowed?
       Refile.allow_uploads_to == :all or Refile.allow_uploads_to.include?(params[:backend])
+    end
+
+    def has_if_modified_since?
+      !request.env["HTTP_IF_MODIFIED_SINCE"].blank?
     end
 
     def logger


### PR DESCRIPTION
Since Refile attachments are immutable I think it makes sense to always return 304 Not Modified when a browser asks if a file has changed since it was last downloaded.

The practical aspect is that resized images are loaded only once, reducing the CPU load of resizing. This is nice in development. I can't speak to the performance increase in production with a CDN but it should help there too when several CDN edge servers ask for the same resource.

If you think this is a good idea I'll write tests for this change.