### PR TITLE
Add option to save processed files in local public folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,18 @@ elloh
 Refile calls `call` on the processor and passes in the retrieved file, as well
 as all additional arguments sent through the URL.
 
+### Saving processed files in public folder
+
+If using CDN is not an option then you probably want to save processed files
+in public folder.
+You should only define `public_path` option like this:
+
+``` ruby
+Refile.public_path = '/your/public/folder'
+# or
+Refile.public_path = Rails.public_path if Rails.env.development?
+```
+
 ## 4. Rails helpers
 
 Refile provides the `attachment_field` form helper which generates a file field
@@ -816,7 +828,7 @@ RSpec.describe Post, type: :model do
 
     expect(post.image_id).not_to be_nil
   end
-  
+
   it "doesn't allow attaching other files" do
     post = Post.new
 

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -129,6 +129,13 @@ module Refile
     # @return [String]
     attr_accessor :secret_key
 
+    # Public path for storing processed files
+    #
+    # The default is nil. That means no files would be stored.
+    #
+    # @return [String]
+    attr_accessor :public_path
+
     # A global registry of backends.
     #
     # @return [Hash{String => Backend}]

--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -133,7 +133,18 @@ module Refile
         IO.copy_stream file, path
       end
 
-      filename = request.path.split("/").last
+      *folders, filename = request.path.split("/")
+
+      if Refile.public_path
+        public_folder = Pathname(Refile.public_path).join(*folders.reject(&:empty?))
+        public_path = ::File.join public_folder, filename
+
+        FileUtils.mkdir_p public_folder
+        FileUtils.move path, public_path
+        FileUtils.chmod "a+r", public_path
+
+        path = public_path
+      end
 
       send_file path, filename: filename, disposition: "inline", type: ::File.extname(request.path)
     end

--- a/spec/refile/app_spec.rb
+++ b/spec/refile/app_spec.rb
@@ -351,4 +351,27 @@ describe Refile::App do
     expect(last_response.content_type).to eq("text/plain;charset=utf-8")
     expect(last_response.body).to eq("not found")
   end
+
+  describe "GET file with public_path provided" do
+    before { allow(Refile).to receive(:public_path).and_return("public") }
+    after { FileUtils.remove_entry_secure "public" }
+
+    it "should save processed file in public folder" do
+      file = Refile.store.upload(StringIO.new("hello"))
+
+      [
+        "/token/store/#{file.id}/hello",
+        "/token/store/#{file.id}/hello.html",
+        "/token/store/reverse/#{file.id}/hello",
+        "/token/store/upcase/#{file.id}/hello",
+        "/token/store/concat/foo/bar/baz/#{file.id}/hello",
+        "/token/store/convert_case/#{file.id}/hello.up"
+      ].each do |path|
+        get path
+
+        expect(last_response.status).to eq(200)
+        expect(File.exist?("public/#{path}")).to eq true
+      end
+    end
+  end
 end


### PR DESCRIPTION
I add an option `Refile.public_path` so everybody who is not gang ho about CDN can preserve processed files in public folder. 
With this change refile would not process the same files over and over with each page reloading.
If you will not set this option than all should work like before.