### PR TITLE
Add aliases to helper methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,8 @@ no file has been uploaded:
 <%= attachment_image_tag(@user, :profile_image, :fill, 300, 300, fallback: "default.png") %>
 ```
 
+All helper methods are available with `refile_` prefix to avoid name clashes
+
 ## 5. JavaScript library
 
 Refile's JavaScript library is small but powerful.

--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -391,6 +391,8 @@ module Refile
       file_url(file, *args, host: host, prefix: prefix, filename: filename, format: format)
     end
 
+    alias_method :refile_attachment_url, :attachment_url
+
     # Receives an instance of a class which has used the
     # {Refile::Attachment#attachment} macro to generate an attachment column,
     # and the name of this column, and based on this generates a URL to a

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -32,6 +32,8 @@ module Refile
       end
     end
 
+    alias_method :refile_attachment_url, :attachment_url
+
     # Generates an image tag for the given attachment, adding appropriate
     # classes and optionally falling back to the given fallback image if there
     # is no file attached.
@@ -53,6 +55,8 @@ module Refile
         image_tag(fallback, options.merge(class: classes))
       end
     end
+
+    alias_method :refile_attachment_image_tag, :attachment_image_tag
 
     # Generates a form field which can be used with records which have
     # attachments. This will generate both a file field as well as a hidden
@@ -92,5 +96,7 @@ module Refile
         data: { reference: options[:data][:reference] }
       ) + file_field(object_name, method, options)
     end
+
+    alias_method :refile_attachment_field, :attachment_field
   end
 end

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -37,7 +37,6 @@ describe Refile::AttachmentHelper do
     end
   end
 
-
   it "has alias methods" do
     %i(refile_attachment_image_tag refile_attachment_field refile_attachment_url).each do |method|
       expect(self.respond_to? method).to be_truthy

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -36,4 +36,11 @@ describe Refile::AttachmentHelper do
       expect(src).to eq "http://localhost:56120#{attachment_path}"
     end
   end
+
+
+  it "has alias methods" do
+    %i(refile_attachment_image_tag refile_attachment_field refile_attachment_url).each do |method|
+      expect(self.respond_to? method).to be_truthy
+    end
+  end
 end

--- a/spec/refile_spec.rb
+++ b/spec/refile_spec.rb
@@ -205,6 +205,12 @@ RSpec.describe Refile do
     end
   end
 
+  describe ".refile_atttachment_url" do
+    it "respons to alias method" do
+      expect(Refile.respond_to? :refile_attachment_url).to be_truthy
+    end
+  end
+
   describe ".upload_url" do
     it "generates an upload url" do
       expect(Refile.upload_url(Refile.cache)).to eq("/cache")


### PR DESCRIPTION
As it was discussed at #270 this adds alias for helper methods and alias to attachment_url from refile module to make it consistent.

I'm not sure if it would be tested since alias_method is language construction
