### PR TITLE
Pass :index option through to hidden field

### DIFF
--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -84,13 +84,16 @@ module Refile
 
       options[:data][:reference] = SecureRandom.hex
 
-      hidden_field(object_name, method,
+      hidden_options = {
         multiple: options[:multiple],
         value: object.send("#{method}_data").try(:to_json),
         object: object,
         id: nil,
         data: { reference: options[:data][:reference] }
-      ) + file_field(object_name, method, options)
+      }
+      hidden_options.merge!(index: options[:index]) if options.key?(:index)
+
+      hidden_field(object_name, method, hidden_options) + file_field(object_name, method, options)
     end
   end
 end

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -6,6 +6,7 @@ require "action_view"
 describe Refile::AttachmentHelper do
   include Refile::AttachmentHelper
   include ActionView::Helpers::AssetTagHelper
+  include ActionView::Helpers::FormHelper
 
   let(:klass) do
     Class.new(ActiveRecord::Base) do
@@ -34,6 +35,17 @@ describe Refile::AttachmentHelper do
 
     it "builds with host" do
       expect(src).to eq "http://localhost:56120#{attachment_path}"
+    end
+  end
+
+  describe "#attachment_field" do
+    context "with index given" do
+      let(:html) { attachment_field("post", :document, object: klass.new, index: 0) }
+
+      it "generates file and hidden inputs with identical names" do
+        expect(html).to include('name="post[0][document]" type="file"')
+        expect(html).to include('name="post[0][document]" type="hidden"')
+      end
     end
   end
 end


### PR DESCRIPTION
Currently, if we call `attachment_field(:image, index: 1)`, Refile omits the `:index` option when rendering the hidden field. This means the hidden field and file field are rendered with different names, e.g.:

```
<input type=hidden name=object[image] ...>
<input type=file   name=object[1][image] ...>
```

This is a bug.

The hidden field and file field need to render with identical `name` attributes in order for file upload to work properly. The name is generated by Rails based on certain options, so we need to make sure that both the field and file receive the same options, at least those options that affect the name. `:index` is one of those options. 

This PR fixes this discrepancy by passing the `:index` option to the hidden field so that the output is correct:

```
<input type=hidden name=object[1][image] ...>
<input type=file   name=object[1][image] ...>
```