### PR TITLE
rails5 updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .config
 .yardoc
 Gemfile.lock
+gemfiles/*.lock
 InstalledFiles
 _yardoc
 coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+AllCops:
+  Exclude:
+    - 'gemfiles/**/*'
+    - 'vendor/**/*'
 Metrics/LineLength:
   Max: 150 # TODO: we should decrease this to 120
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,11 @@ before_script:
   - sh -e /etc/init.d/xvfb start
 
 matrix:
+  include:
+    - rvm: 2.2.4
+      gemfile: gemfiles/Gemfile.rails-5.0-master
   allow_failures:
     - rvm: ruby-head
+    - rvm: 2.2.4
+      gemfile: gemfiles/Gemfile.rails-5.0-master
+

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ RSpec::Core::RakeTask.new(:spec)
 
 RuboCop::RakeTask.new
 
-task default: [:spec, :rubocop]
-
 Rails.application.load_tasks
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: [:spec, :rubocop]

--- a/gemfiles/Gemfile.rails-5.0-master
+++ b/gemfiles/Gemfile.rails-5.0-master
@@ -1,0 +1,31 @@
+source "https://rubygems.org"
+
+gemspec path: '..'
+
+gem "webmock", "~> 1.20.4"
+gem "bundler", "~> 1.6"
+gem "rake"
+gem "jquery-rails"
+gem "capybara", github: 'jnicklas/capybara'
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "sqlite3",                          platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~>0.33.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "rails", github: "rails/rails"
+gem "arel", github: "rails/arel"
+gem "rack", github: "rack/rack"
+gem "rspec-rails", github: "rspec/rspec-rails"
+gem "rspec", github: "rspec/rspec"
+gem "rspec-core", github: "rspec/rspec-core"
+gem "rspec-support", github: "rspec/rspec-support"
+gem "rspec-expectations", github: "rspec/rspec-expectations"
+gem "rspec-mocks", github: "rspec/rspec-mocks"
+gem "sinatra", github: "sinatra/sinatra", branch: "2.2.0-alpha"

--- a/refile.gemspec
+++ b/refile.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_dependency "rest-client", "~> 1.8"
-  spec.add_dependency "sinatra", "~> 1.4.5"
+  spec.add_dependency "sinatra", ">= 1.4.5"
   spec.add_dependency "mime-types"
 end

--- a/spec/refile/active_record_helper.rb
+++ b/spec/refile/active_record_helper.rb
@@ -32,6 +32,4 @@ class TestMigration < ActiveRecord::Migration
   end
 end
 
-quietly do
-  TestMigration.up
-end
+TestMigration.up

--- a/spec/refile/app_spec.rb
+++ b/spec/refile/app_spec.rb
@@ -4,7 +4,9 @@ describe Refile::App do
   include Rack::Test::Methods
 
   def app
-    Refile::App.new
+    res = Refile::App.new
+    res.settings.set :public_folder, ""
+    res
   end
 
   before do
@@ -14,7 +16,6 @@ describe Refile::App do
   describe "GET /:backend/:id/:filename" do
     it "returns a stored file" do
       file = Refile.store.upload(StringIO.new("hello"))
-
       get "/token/store/#{file.id}/hello"
 
       expect(last_response.status).to eq(200)
@@ -23,7 +24,6 @@ describe Refile::App do
 
     it "sets appropriate content type from extension" do
       file = Refile.store.upload(StringIO.new("hello"))
-
       get "/token/store/#{file.id}/hello.html"
 
       expect(last_response.status).to eq(200)

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -40,11 +40,12 @@ describe Refile::AttachmentHelper do
 
   describe "#attachment_field" do
     context "with index given" do
-      let(:html) { attachment_field("post", :document, object: klass.new, index: 0) }
+      let(:html) { Capybara.string(attachment_field("post", :document, object: klass.new, index: 0)) }
 
       it "generates file and hidden inputs with identical names" do
-        expect(html).to include('name="post[0][document]" type="file"')
-        expect(html).to include('name="post[0][document]" type="hidden"')
+        field_name = "post[0][document]"
+        expect(html).to have_field(field_name, type: "file")
+        expect(html).to have_selector(:css, "input[name='#{field_name}'][type=hidden]", visible: false)
       end
     end
   end


### PR DESCRIPTION
This updates refile to test with Rails master branch (rails 5) and fixes all failing tests.  There is still an error when running the tests on travis since for some reason it attempts to load a 'test' file after running rubocop -   I don't have time right now to figure out why, if anyone has any ideas please let me know.  Note currently this requires using a non-official branch of sinatra, hopefully that changes soon