### PR TITLE
Use different escape method for filename

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -312,7 +312,7 @@ module Refile
       host ||= Refile.cdn_host
       backend_name = Refile.backends.key(file.backend)
 
-      filename = Rack::Utils.escape(filename)
+      filename = Rack::Utils.escape_path(filename)
       filename << "." << format.to_s if format
 
       base_path = ::File.join("", backend_name, *args.map(&:to_s), file.id.to_s, filename)

--- a/spec/refile_spec.rb
+++ b/spec/refile_spec.rb
@@ -117,6 +117,7 @@ RSpec.describe Refile do
     it "adds an escaped filename" do
       expect(Refile.file_url(file, filename: "test.png")).to eq("/token/cache/#{id}/test.png")
       expect(Refile.file_url(file, filename: "tes/t.png")).to eq("/token/cache/#{id}/tes%2Ft.png")
+      expect(Refile.file_url(file, filename: "tes t.png")).to eq("/token/cache/#{id}/tes%20t.png")
     end
 
     it "adds a format" do


### PR DESCRIPTION
This change will make it so escape doesn't replace " " to "+" and downloaded files will have more readable names. (ie `test+example.txt` vs `text example.txt`)
