### PR TITLE
Readme for manual mounting apps with catch-all routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,24 @@ to see this when you run `rake routes`.
 You could also run the application on its own, it doesn't need to be mounted to
 work.
 
+If you are using a catch-all route (such as required by Comfy CMS), you will need to turn off Automounting and add the refile route before your catch all route.
+
+(in initializers/refile.rb)
+``` ruby
+Refile.automount = false
+```
+
+in routes.rb
+``` ruby
+  mount Refile.app, at: Refile.mount_point, as: :refile_app
+
+  # Make sure this routeset is defined last
+  comfy_route :cms, :path => '/', :sitemap => true
+
+```
+
+
+
 ### Retrieving files
 
 Files can be retrieved from the application by calling:


### PR DESCRIPTION
Added some documentation if you use a catch-all route (for a CMS like [Comfortable Mexican Sofa](https://github.com/comfy/comfortable-mexican-sofa) ) which breaks Refile attachment routing
