### PR TITLE
Resizing images before upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ cache: bundler
 
 sudo: false
 
+before_install:
+  - mkdir travis-phantomjs
+  - wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
+
 before_script:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
@@ -25,4 +31,3 @@ matrix:
     - rvm: ruby-head
     - rvm: 2.2.4
       gemfile: gemfiles/Gemfile.rails-5.0-master
-

--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -19,7 +19,157 @@
     return data;
   }
 
+  function resizeParams(file, input) {
+    var info, srcRatio, trgRatio;
+
+    info = {
+      srcX: 0,
+      srcY: 0,
+      srcWidth: file.width,
+      srcHeight: file.height
+    };
+    srcRatio = file.width / file.height;
+
+    info.maxWidth = parseInt(input.dataset.maxWidth);
+    info.maxHeight = parseInt(input.dataset.maxHeight);
+
+    // Make sure it still works even if only one max size is defined
+    if(isNaN(info.maxWidth)) info.maxWidth = info.maxHeight
+    if(isNaN(info.maxHeight)) info.maxHeight = info.maxWidth
+
+    trgRatio = info.maxWidth / info.maxHeight;
+
+    if (file.width > info.maxWidth || file.height > info.maxHeight) {
+      if (file.width > file.height) {
+        info.trgWidth = info.maxWidth
+        info.trgHeight = file.height * (info.maxWidth / file.width)
+      } else {
+        info.trgHeight = info.maxHeight
+        info.trgWidth = file.width * (info.maxHeight / file.height)
+      }
+    } else {
+      info.trgHeight = info.srcHeight;
+      info.trgWidth = info.srcWidth;
+    }
+
+    info.srcX = (file.width - info.srcWidth) / 2;
+    info.srcY = (file.height - info.srcHeight) / 2;
+
+    return info;
+  }
+
+  function detectVerticalSquash(img) {
+    var alpha, canvas, ctx, data, ey, ih, iw, py, ratio, sy;
+    iw = img.naturalWidth;
+    ih = img.naturalHeight;
+    canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = ih;
+    ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    data = ctx.getImageData(0, 0, 1, ih).data;
+    sy = 0;
+    ey = ih;
+    py = ih;
+    while (py > sy) {
+      alpha = data[(py - 1) * 4 + 3];
+      if (alpha === 0) {
+        ey = py;
+      } else {
+        sy = py;
+      }
+      py = (ey + sy) >> 1;
+    }
+    ratio = py / ih;
+    if (ratio === 0) {
+      return 1;
+    } else {
+      return ratio;
+    }
+  }
+
+  function drawImageIOSFix(ctx, img, sx, sy, sw, sh, dx, dy, dw, dh) {
+    var vertSquashRatio;
+    vertSquashRatio = detectVerticalSquash(img);
+    return ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh / vertSquashRatio);
+  };
+
+  function dataURLToBlob(dataURL) {
+    var BASE64_MARKER, contentType, i, parts, raw, rawLength, uInt8Array;
+    BASE64_MARKER = ";base64,";
+    if (dataURL.indexOf(BASE64_MARKER) === -1) {
+      parts = dataURL.split(",");
+      contentType = parts[0].split(":")[1];
+      raw = decodeURIComponent(parts[1]);
+      return new Blob([raw], {
+        type: contentType
+      });
+    }
+    parts = dataURL.split(BASE64_MARKER);
+    contentType = parts[0].split(":")[1];
+    raw = window.atob(parts[1]);
+    rawLength = raw.length;
+    uInt8Array = new Uint8Array(rawLength);
+    i = 0;
+    while (i < rawLength) {
+      uInt8Array[i] = raw.charCodeAt(i);
+      ++i;
+    }
+    return new Blob([uInt8Array], {
+      type: contentType
+    });
+  };
+
+  function resizeImage(file, input, index, callback) {
+    var fileReader = new FileReader;
+
+    fileReader.onload = (function(_this) {
+      return function() {
+        if (file.type === "image/svg+xml") return;
+
+        var img = document.createElement("img");
+
+        img.onload = function() {
+          var canvas, ctx, resizeInfo, resizedImage, _ref, _ref1, _ref2, _ref3;
+          file.width = img.width;
+          file.height = img.height;
+          resizeInfo = resizeParams(file, input);
+          if (resizeInfo.trgWidth == null) {
+            resizeInfo.trgWidth = resizeInfo.maxWidth;
+          }
+          if (resizeInfo.trgHeight == null) {
+            resizeInfo.trgHeight = resizeInfo.maxHeight;
+          }
+          canvas = document.createElement("canvas");
+          ctx = canvas.getContext("2d");
+          canvas.width = resizeInfo.trgWidth;
+          canvas.height = resizeInfo.trgHeight;
+          drawImageIOSFix(
+            ctx,
+            img,
+            (_ref = resizeInfo.srcX) != null ? _ref : 0,
+            (_ref1 = resizeInfo.srcY) != null ? _ref1 : 0,
+            resizeInfo.srcWidth,
+            resizeInfo.srcHeight,
+            (_ref2 = resizeInfo.trgX) != null ? _ref2 : 0,
+            (_ref3 = resizeInfo.trgY) != null ? _ref3 : 0,
+            resizeInfo.trgWidth,
+            resizeInfo.trgHeight
+          );
+          resizedImage = canvas.toDataURL("image/png");
+          input.files[index].resized = resizedImage;
+          requests.push(callback(file, index));
+        };
+        img.src = fileReader.result;
+      };
+    })(this);
+
+    fileReader.readAsDataURL(file);
+  }
+
   if(!document.addEventListener) { return; } // IE8
+
+  var requests = []
 
   document.addEventListener("change", function(changeEvent) {
     var input = changeEvent.target;
@@ -32,7 +182,14 @@
       var url = input.getAttribute("data-url");
       var fields = JSON.parse(input.getAttribute("data-fields") || "null");
 
-      var requests = [].map.call(input.files, function(file, index) {
+      for(var i = 0; i < input.files.length; i++) {
+        if(input.getAttribute("data-max-width") || input.getAttribute("data-max-height"))
+          resizeImage(input.files[i], input, i, createRequest);
+        else
+          requests.push(createRequest(file, index));
+      }
+
+      function createRequest(file, index) {
         function dispatchEvent(element, name, progress) {
           var ev = document.createEvent('CustomEvent');
           ev.initCustomEvent(name, true, false, { xhr: xhr, file: file, index: index, progress: progress });
@@ -59,6 +216,8 @@
         xhr.upload.addEventListener("progress", function(progressEvent) {
           dispatchEvent(input, "upload:progress", progressEvent);
         });
+
+        var fileData = file.resized ? dataURLToBlob(file.resized) : file;
 
         if(input.getAttribute("data-presigned")) {
           dispatchEvent(input, "presign:start");
@@ -87,9 +246,9 @@
         }
 
         return xhr;
-      });
+      };
 
-      if(requests.length) {
+      if(input.files.length) {
         input.classList.add("uploading");
       }
 

--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -183,7 +183,10 @@
       var fields = JSON.parse(input.getAttribute("data-fields") || "null");
 
       for(var i = 0; i < input.files.length; i++) {
-        if(input.getAttribute("data-max-width") || input.getAttribute("data-max-height"))
+        if((input.getAttribute("data-max-width")
+          || input.getAttribute("data-max-height"))
+            && input.files[i].type.match(/image.*/))
+
           resizeImage(input.files[i], input, i, createRequest);
         else
           requests.push(createRequest(file, index));
@@ -246,7 +249,7 @@
         }
 
         return xhr;
-      };
+      }
 
       if(input.files.length) {
         input.classList.add("uploading");

--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -230,7 +230,7 @@
               var data = JSON.parse(presignXhr.responseText)
               xhr.id = data.id;
               xhr.open("POST", data.url, true);
-              xhr.send(formData(data.as, file, data.fields));
+              xhr.send(formData(data.as, fileData, data.fields));
               dispatchEvent(input, "upload:start");
             } else {
               dispatchEvent(input, "presign:failure");
@@ -241,7 +241,7 @@
           presignXhr.send();
         } else {
           xhr.open("POST", url, true);
-          xhr.send(formData(input.getAttribute("data-as"), file, fields));
+          xhr.send(formData(input.getAttribute("data-as"), fileData, fields));
           dispatchEvent(input, "upload:start");
         }
 

--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -182,17 +182,7 @@
       var url = input.getAttribute("data-url");
       var fields = JSON.parse(input.getAttribute("data-fields") || "null");
 
-      for(var i = 0; i < input.files.length; i++) {
-        if((input.getAttribute("data-max-width")
-          || input.getAttribute("data-max-height"))
-            && input.files[i].type.match(/image.*/))
-
-          resizeImage(input.files[i], input, i, createRequest);
-        else
-          requests.push(createRequest(file, index));
-      }
-
-      function createRequest(file, index) {
+      var createRequest = function(file, index) {
         function dispatchEvent(element, name, progress) {
           var ev = document.createEvent('CustomEvent');
           ev.initCustomEvent(name, true, false, { xhr: xhr, file: file, index: index, progress: progress });
@@ -249,6 +239,16 @@
         }
 
         return xhr;
+      }
+
+      for(var i = 0; i < input.files.length; i++) {
+        if((input.getAttribute("data-max-width")
+          || input.getAttribute("data-max-height"))
+            && input.files[i].type.match(/image.*/))
+
+          resizeImage(input.files[i], input, i, createRequest);
+        else
+          requests.push(createRequest(input.files[i], i));
       }
 
       if(input.files.length) {

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -82,6 +82,9 @@ module Refile
         options[:data].merge!(direct: true, presigned: true, url: url)
       end
 
+      options[:data].merge!(max_width: options[:max_width]) if options[:max_width]
+      options[:data].merge!(max_height: options[:max_height]) if options[:max_height]
+
       options[:data][:reference] = SecureRandom.hex
 
       hidden_options = {

--- a/spec/refile/features/resize_image_upload_spec.rb
+++ b/spec/refile/features/resize_image_upload_spec.rb
@@ -1,0 +1,29 @@
+require "refile/test_app"
+
+feature "Direct HTTP post file uploads", :js do
+  scenario "Successfully resize an image before upload it" do
+    visit "/resize_image/posts/new"
+    fill_in "Title", with: "A cool post"
+    attach_file "Image", path("image.jpg")
+
+    expect(page).to have_content("Upload started")
+    expect(page).to have_content("Upload success")
+    expect(page).to have_content("Upload complete")
+
+    click_button "Create"
+
+    expect(page).to have_selector("h1", text: "A cool post")
+    expect(page).to have_selector("img")
+
+    start = Time.now
+    loop do
+      break if find("img")["complete"]
+
+      fail "Image still not loaded" if Time.now > start + 5.seconds
+
+      sleep 0.1
+    end
+
+    expect(page.evaluate_script("$('img')[0].clientWidth")).to eq 400
+  end
+end

--- a/spec/refile/test_app/app/controllers/resize_image_posts_controller.rb
+++ b/spec/refile/test_app/app/controllers/resize_image_posts_controller.rb
@@ -1,0 +1,15 @@
+class ResizeImagePostsController < ApplicationController
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.new(params.require(:post).permit(:title, :document, :image, :requires_document, documents_files: []))
+
+    if @post.save
+      redirect_to [:normal, @post]
+    else
+      render :new
+    end
+  end
+end

--- a/spec/refile/test_app/app/views/resize_image_posts/new.html.erb
+++ b/spec/refile/test_app/app/views/resize_image_posts/new.html.erb
@@ -1,0 +1,16 @@
+<%= form_for [:resize_image, @post], html: { id: "direct" } do |form| %>
+  <p>
+    <%= @post.errors.full_messages.to_sentence %>
+  </p>
+  <p>
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </p>
+  <p>
+    <%= form.label :image %>
+    <%= form.attachment_field :image, direct: true, max_width: 400 %>
+  </p>
+  <p>
+    <%= form.submit "Create" %>
+  </p>
+<% end %>

--- a/spec/refile/test_app/config/routes.rb
+++ b/spec/refile/test_app/config/routes.rb
@@ -19,6 +19,10 @@ Refile::TestApp.routes.draw do
     end
   end
 
+  scope path: "resize_image", as: "resize_image" do
+    resources :posts, only: [:new, :create], controller: "resize_image_posts"
+  end
+
   scope path: "simple_form", as: "simple_form" do
     resources :posts, only: [:new, :create], controller: "simple_form_posts"
   end


### PR DESCRIPTION
Gives support for max_width and max_height options for attachment_field helper so users can resize images before direct uploads
