### PR TITLE
Don't submit file metadata through form if it hasn't changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Will generate something like:
 
 ``` html
 <form action="/users" enctype="multipart/form-data" method="post">
-  <input name="user[profile_image]" type="hidden">
+  <input name="user[profile_image]" type="text" style="display:none;">
   <input name="user[profile_image]" type="file">
 </form>
 ```
@@ -816,7 +816,7 @@ RSpec.describe Post, type: :model do
 
     expect(post.image_id).not_to be_nil
   end
-  
+
   it "doesn't allow attaching other files" do
     post = Post.new
 

--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -27,7 +27,7 @@
       if(!input.files) { return; } // IE9, bail out if file API is not supported.
 
       var reference = input.getAttribute("data-reference");
-      var metadataField = document.querySelector("input[type=hidden][data-reference='" + reference + "']");
+      var metadataField = document.querySelector("input[type=text][data-reference='" + reference + "']");
 
       var url = input.getAttribute("data-url");
       var fields = JSON.parse(input.getAttribute("data-fields") || "null");
@@ -102,7 +102,10 @@
             return { id: id, filename: xhr.file.name, content_type: xhr.file.type, size: xhr.file.size };
           });
           if(!input.multiple) data = data[0];
-          if(metadataField) metadataField.value = JSON.stringify(data);
+          if(metadataField) {
+            metadataField.value = JSON.stringify(data);
+            metadataField.removeAttribute('disabled');
+          }
 
           input.removeAttribute("name");
         }

--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -82,18 +82,22 @@ module Refile
         options[:data].merge!(direct: true, presigned: true, url: url)
       end
 
+      attacher_value = object.send("#{method}_data")
+
       options[:data][:reference] = SecureRandom.hex
 
-      hidden_options = {
-        multiple: options[:multiple],
-        value: object.send("#{method}_data").try(:to_json),
-        object: object,
-        id: nil,
-        data: { reference: options[:data][:reference] }
-      }
-      hidden_options.merge!(index: options[:index]) if options.key?(:index)
+      hidden_options = {}.tap do |opts|
+        opts[:id] = nil
+        opts[:style] = "display: none;"
+        opts[:multiple] = options[:multiple]
+        opts[:value] = attacher_value.try(:to_json)
+        opts[:object] = object
+        opts[:data] = { reference: options[:data][:reference] }
+        opts[:index] = options[:index] if options.key?(:index)
+        opts[:disabled] = true if attacher_value.blank?
+      end
 
-      hidden_field(object_name, method, hidden_options) + file_field(object_name, method, options)
+      text_field(object_name, method, hidden_options) + file_field(object_name, method, options)
     end
   end
 end


### PR DESCRIPTION
I came across an unexpected behaviour when using the `attachment_field` helper.

**This is an example of how it behaves:**
1. I opened up `users/edit`, changed the user's email and submitted the form without changing the file field `profile_image`, which was blank (never uploaded).
2. Even though I hadn't changed it, my controller received a `user[profile_image]` param with `"{}"` value.
3. That polluted Rails Dirty (e.g. `model.changes`, `model.profile_image_changed?`) with changes that didn't really happen, and I was kinda counting on it to do some stuff.

I was expecting the file param to not be sent to the controller when blank/unchanged, since this is how the native file input behaves. But because of the hidden field, it would always be sent, no matter what.

So, first I tried to add a `disabled` attribute to the hidden field, but it didn't work, 'cause hidden fields don't support it.
Then I tried changing it to a text field, which supports `disabled` attribute, and hid it via stylesheet.

It worked, but I still feel like it's not a very elegant solution.

What do you guys think? Any suggestions?
