### PR TITLE
Add notice to Refile.secret_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ The `:token` is a generated digest of the request path when the
 `Refile.secret_key` is configured; otherwise, the application will raise an error.
 The digest feature provides a security measure against unverified requests.
 
+**NOTICE:** If you don't set the `Refile.secret_key` we will use rails `secret_key_base`
+to generate the token. We suggest you not to change the `secret_key_base` after you
+generated and hardcoded some attachment URLs in your application (e.g. blog post images),
+because the token will change and you'll not be able to retrieve in this case, the images.
+
 ### Processing
 
 Refile provides on the fly processing of files. You can trigger it by calling
@@ -816,7 +821,7 @@ RSpec.describe Post, type: :model do
 
     expect(post.image_id).not_to be_nil
   end
-  
+
   it "doesn't allow attaching other files" do
     post = Post.new
 


### PR DESCRIPTION
We had a situation where we needed to change our `secret_key_base` due to a security policy and because we had some hard coded images (refile attachments) on our blog post everything broke.

After digging a while we realized that refile is using rails `secret_key_base` to generate to token, so it would be nice to have that written in the readme
