### PR TITLE
Return presigned URL from S3

### DIFF
--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -18,6 +18,7 @@ module Refile
     # - `remote_image_url`
     # - `remote_image_url=`
     # - `image_url`
+    # - `image_presigned_url`
     #
     # @example
     #   class User
@@ -86,6 +87,11 @@ module Refile
 
         define_method "#{name}_url" do |*args|
           Refile.attachment_url(self, name, *args)
+        end
+
+        define_method "presigned_#{name}_url" do |expires_in = 900|
+          _attacher = send(attacher)
+          _attacher.store.object(_attacher.id).presigned_url(:get, expires_in: expires_in) unless _attacher.id.nil?
         end
 
         define_method "#{name}_data" do

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -113,6 +113,28 @@ describe Refile::Attachment do
     end
   end
 
+  describe "presigned_:name_url=" do
+    it "generates presigned URL" do
+      file = Refile.store.upload(Refile::FileDouble.new("hello"))
+      instance.document_id = file.id
+
+      allow(Refile.store).to receive_message_chain(:object, :presigned_url).with(file.id).with(:get, expires_in: 900).and_return("PRESIGNED_URL")
+      expect(instance.presigned_document_url).to eq("PRESIGNED_URL")
+    end
+
+    it "generates presigned URL with custom expiration" do
+      file = Refile.store.upload(Refile::FileDouble.new("hello"))
+      instance.document_id = file.id
+
+      allow(Refile.store).to receive_message_chain(:object, :presigned_url).with(file.id).with(:get, expires_in: 901).and_return("PRESIGNED_URL")
+      expect(instance.presigned_document_url(901)).to eq("PRESIGNED_URL")
+    end
+
+    it "does nothing when id is nill" do
+      expect(instance.presigned_document_url).to be_nil
+    end
+  end
+
   describe "remote_:name_url=" do
     it "does nothing when nil is assigned" do
       instance.remote_document_url = nil


### PR DESCRIPTION
Sometimes it is important to have de presigned URL from Amazon S3. 
It is much faster read direct from there.
