### PR TITLE
Prevent rails (5) to add an extra hidden input

### DIFF
--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -83,6 +83,7 @@ module Refile
       end
 
       options[:data][:reference] = SecureRandom.hex
+      options[:include_hidden] = false
 
       hidden_options = {
         multiple: options[:multiple],

--- a/spec/refile/attachment_helper_spec.rb
+++ b/spec/refile/attachment_helper_spec.rb
@@ -45,7 +45,7 @@ describe Refile::AttachmentHelper do
       it "generates file and hidden inputs with identical names" do
         field_name = "post[0][document]"
         expect(html).to have_field(field_name, type: "file")
-        expect(html).to have_selector(:css, "input[name='#{field_name}'][type=hidden]", visible: false)
+        expect(html).to have_selector(:css, "input[name='#{field_name}'][type=hidden]", visible: false, count: 1)
       end
     end
   end


### PR DESCRIPTION
Rails 5 adds a hidden input field for file fields: [commit here](https://github.com/rails/rails/commit/00b26532f05283d2b160308522d1bd2146d6ac18). This breaks refile's keeping the uploaded file across form redisplay (like other fields validations). This PR fixes that by passing the `include_hidden` to the file_filed call.