### PR TITLE
Fix multibyte filename when file downloading on Firefox 48.0.

### DIFF
--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -1,6 +1,7 @@
 require "json"
 require "sinatra/base"
 require "tempfile"
+require "cgi"
 
 module Refile
   # A Rack application which can be mounted or run on its own.
@@ -136,8 +137,9 @@ module Refile
       end
 
       filename = request.path.split("/").last
+      decoded_filename = CGI.unescape(filename)
 
-      send_file path, filename: filename, disposition: "inline", type: ::File.extname(request.path)
+      send_file path, filename: decoded_filename, disposition: "inline", type: ::File.extname(request.path)
     end
 
     def backend


### PR DESCRIPTION
When download uploaded file that named by multibyte charactors（like "てすと.pdf" in Japanese） on Firefox,
downloaded file name is garbled（like "%E3%81%A6%E3%81%99%E3%81%A8.pdf"）.
