### PR TITLE
Prevent from exposing secure information unexpectedly

### DIFF
--- a/lib/refile/file.rb
+++ b/lib/refile/file.rb
@@ -83,6 +83,16 @@ module Refile
       @io = nil
     end
 
+    # Prevent from exposing secure information unexpectedly
+    #
+    # @return [Hash]
+    def as_json(options={})
+      {
+        id: id,
+        backend: backend.to_s
+      }
+    end
+
   private
 
     def io

--- a/refile.gemspec
+++ b/refile.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.add_dependency "rest-client", "~> 1.8"
-  spec.add_dependency "sinatra", ">= 1.4.5"
+  spec.add_dependency "sinatra", "~> 2.0.0"
   spec.add_dependency "mime-types"
 end


### PR DESCRIPTION
I'm using refile with Amazon S3.

I found `Refile::File` class potentially exposes important backend information (includes AWS Secret Key! )

```ruby
# entity.rb
class Entity < ApplicationRecord
  attachment :image
end

# in jbuilder view, @entity is Entity's instance
json.image @entity.image
```

or, `@entity.image.as_json` in rails console.

Although I know this jbuilder code is wrong, but someone might writes this code.

I think important information should not revealed with trivial human error.