### PR TITLE
Travis: update CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
+dist: trusty
 
 rvm:
-  - 2.1
-  - 2.2.4
+  - 2.1.10
+  - 2.2.7
   - 2.3.4
   - 2.4.1
   - ruby-head
@@ -21,9 +22,9 @@ before_script:
 
 matrix:
   include:
-    - rvm: 2.2.4
+    - rvm: 2.2.7
       gemfile: gemfiles/Gemfile.rails-5.0-master
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.2.4
+    - rvm: 2.2.7
       gemfile: gemfiles/Gemfile.rails-5.0-master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: ruby
 
 rvm:
   - 2.1
-  - 2.2
+  - 2.2.4
+  - 2.3.4
+  - 2.4.1
   - ruby-head
-  - jruby-9.0.1.0
+  - jruby-9.1.12.0
 
 gemfile:
   - Gemfile
@@ -25,4 +27,3 @@ matrix:
     - rvm: ruby-head
     - rvm: 2.2.4
       gemfile: gemfiles/Gemfile.rails-5.0-master
-


### PR DESCRIPTION
This PR only updates the CI matrix to the latest generally available Ruby versions.

Source for version numbers: https://github.com/rbenv/ruby-build/tree/master/share/ruby-build