### PR TITLE
Disallow zero byte file upload

### DIFF
--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -50,6 +50,7 @@ module Refile
       errors << :invalid_extension if valid_extensions and not extension_included
       errors << :invalid_content_type if valid_content_types and not valid_content_types.include?(attacher.content_type)
       errors << :too_large if cache.max_size and attacher.size and attacher.size >= cache.max_size
+      errors << :zero_byte_detected if attacher.size.to_i.zero?
       errors
     end
   end

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -52,7 +52,7 @@ describe Refile::ActiveRecord::Attachment do
         it "returns true when extension is included in list" do
           file = Refile.cache.upload(StringIO.new("hello"))
           post = klass.new
-          post.document = { id: file.id, filename: "image.Png" }.to_json
+          post.document = { id: file.id, filename: "image.Png", size: file.size }.to_json
           expect(post.valid?).to be_truthy
           expect(post.errors[:document]).to be_empty
         end
@@ -60,7 +60,7 @@ describe Refile::ActiveRecord::Attachment do
         it "returns true when extension is included in list but chars are randomcase" do
           file = Refile.cache.upload(StringIO.new("hello"))
           post = klass.new
-          post.document = { id: file.id, filename: "image.PNG" }.to_json
+          post.document = { id: file.id, filename: "image.PNG", size: file.size }.to_json
           expect(post.valid?).to be_truthy
           expect(post.errors[:document]).to be_empty
         end
@@ -68,7 +68,15 @@ describe Refile::ActiveRecord::Attachment do
         it "returns false when extension is invalid" do
           file = Refile.cache.upload(StringIO.new("hello"))
           post = klass.new
-          post.document = { id: file.id, filename: "image.jpg" }.to_json
+          post.document = { id: file.id, filename: "image.jpg", size: file.size }.to_json
+          expect(post.valid?).to be_falsy
+          expect(post.errors[:document].length).to eq(1)
+        end
+
+        it "returns false when file size is zero" do
+          file = Refile.cache.upload(StringIO.new("hello"))
+          post = klass.new
+          post.document = { id: file.id, filename: "image.Png" }.to_json
           expect(post.valid?).to be_falsy
           expect(post.errors[:document].length).to eq(1)
         end
@@ -153,9 +161,9 @@ describe Refile::ActiveRecord::Attachment do
 
     context "with metadata" do
       it "returns false when metadata doesn't have an id" do
-        Refile.cache.upload(StringIO.new("hello"))
+        file = Refile.cache.upload(StringIO.new("hello"))
         post = klass.new
-        post.document = { content_type: "text/png" }.to_json
+        post.document = { content_type: "text/png", size: file.size }.to_json
         expect(post.valid?).to be_falsy
         expect(post.errors[:document].length).to eq(1)
       end
@@ -163,15 +171,23 @@ describe Refile::ActiveRecord::Attachment do
       it "returns false when type is invalid" do
         file = Refile.cache.upload(StringIO.new("hello"))
         post = klass.new
-        post.document = { id: file.id, content_type: "text/png" }.to_json
+        post.document = { id: file.id, content_type: "text/png", size: file.size }.to_json
         expect(post.valid?).to be_falsy
         expect(post.errors[:document].length).to eq(1)
       end
 
-      it "returns true when type is invalid" do
+      it "returns false when file size is zero" do
+        file = Refile.cache.upload(StringIO.new(""))
+        post = klass.new
+        post.document = { id: file.id, content_type: "image/png", size: file.size }.to_json
+        expect(post.valid?).to be_falsy
+        expect(post.errors[:document].length).to eq(1)
+      end
+
+      it "returns true when type is valid" do
         file = Refile.cache.upload(StringIO.new("hello"))
         post = klass.new
-        post.document = { id: file.id, content_type: "image/png" }.to_json
+        post.document = { id: file.id, content_type: "image/png", size: file.size }.to_json
         expect(post.valid?).to be_truthy
         expect(post.errors[:document]).to be_empty
       end

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -359,6 +359,14 @@ describe Refile::Attachment do
       expect(instance.document_attacher.valid?).to be_falsy
       expect(instance.document_attacher.errors).to eq([:invalid_content_type])
     end
+
+    it "returns false and sets errors if file with zero byte is uploaded" do
+      file = Refile::FileDouble.new("", "hello", content_type: "image/png")
+      instance.document = file
+
+      expect(instance.document_attacher.valid?).to be_falsy
+      expect(instance.document_attacher.errors).to eq([:zero_byte_detected])
+    end
   end
 
   describe ":name_attacher.extension" do


### PR DESCRIPTION
I am using Refile and [Minimagick](https://github.com/minimagick/minimagick) to resize my images on the fly, and sometime our system admin will accidentally upload zero byte file to our server. Then minimagick will raise error when it wants to resize the zero byte file.

Because of this, this PR adds a new option to validate the file size is zero byte or not. Set `allow_zero_byte` to `false` will raise error when users try upload zero byte file to the server.

@sobrinho please let me know this new feature is good to go, so that i will update the README. Thanks!!!