### PR TITLE
Allow assign file to non trackable attribute

### DIFF
--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -24,7 +24,7 @@ module Refile
         end
 
         define_method "#{name}=" do |value|
-          send("#{name}_id_will_change!")
+          send("#{name}_id_will_change!") if respond_to?("#{name}_id_will_change!")
           super(value)
         end
 

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -480,4 +480,20 @@ describe Refile::ActiveRecord::Attachment do
       end
     end
   end
+
+  context "when assigned to an attribute that does not track changes" do
+    let(:klass) do
+      Class.new(ActiveRecord::Base) do
+        self.table_name = :posts
+
+        attachment :not_trackable_attribute
+      end
+    end
+
+    it "assigns the file to the attribute" do
+      post = klass.new
+      post.not_trackable_attribute = Refile::FileDouble.new("foo")
+      expect(post.not_trackable_attribute.read).to eq("foo")
+    end
+  end
 end


### PR DESCRIPTION
I do not know if this correction is still wanted.

Fixes an error that occurs when trying to assign a file to an attribute that does not track changes or which class inherits from ActiveRecord::Base but does not implement ActiveModel::Dirty.

https://github.com/refile/refile/issues/370