### PR TITLE
Custom msg format validation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,3 +6,5 @@ en:
         download_failed: "could not be downloaded"
         invalid_content_type: "You are not allowed to upload %{content} file format. Allowed types: %{permitted}."
         invalid_extension: "You are not allowed to upload %{extension} file extension. Allowed types: %{permitted}."
+  refile:
+    empty_param: "an empty"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,5 +4,5 @@ en:
       messages:
         too_large: "is too large"
         download_failed: "could not be downloaded"
-        invalid_content_type: "has an invalid file format"
-        invalid_extension: "has an invalid file format"
+        invalid_content_type: "You are not allowed to upload %{content} file format. Allowed types: %{permitted}."
+        invalid_extension: "You are not allowed to upload %{extension} file extension. Allowed types: %{permitted}."

--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -18,7 +18,7 @@ module Refile
             send(attacher).valid?
             errors = send(attacher).errors
             errors.each do |error|
-              self.errors.add(name, error)
+              self.errors.add(name, *error)
             end
           end
         end

--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -45,13 +45,38 @@ module Refile
     end
 
     def validate(attacher)
+      extension = attacher.extension.to_s.downcase
+      content_type = attacher.content_type.to_s.downcase
+
       errors = []
-      extension_included = valid_extensions && valid_extensions.map(&:downcase).include?(attacher.extension.to_s.downcase)
-      errors << :invalid_extension if valid_extensions and not extension_included
-      errors << :invalid_content_type if valid_content_types and not valid_content_types.include?(attacher.content_type)
+      errors << extension_error_params(extension) if invalid_extension?(extension)
+      errors << content_type_error_params(content_type) if invalid_content_type?(content_type)
       errors << :too_large if cache.max_size and attacher.size and attacher.size >= cache.max_size
       errors << :zero_byte_detected if attacher.size.to_i.zero?
       errors
+    end
+
+  private
+
+    def extension_error_params(extension)
+      [:invalid_extension, extension: format_param(extension), permitted: valid_extensions.join(", ")]
+    end
+
+    def content_type_error_params(content_type)
+      [:invalid_content_type, content: format_param(content_type), permitted: valid_content_types.join(", ")]
+    end
+
+    def invalid_extension?(extension)
+      extension_included = valid_extensions && valid_extensions.map(&:downcase).include?(extension)
+      valid_extensions and not extension_included
+    end
+
+    def invalid_content_type?(content_type)
+      valid_content_types and not valid_content_types.include?(content_type)
+    end
+
+    def format_param(param)
+      param.empty? ? "an empty" : param
     end
   end
 end

--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -59,11 +59,11 @@ module Refile
   private
 
     def extension_error_params(extension)
-      [:invalid_extension, extension: format_param(extension), permitted: valid_extensions.join(", ")]
+      [:invalid_extension, extension: format_param(extension), permitted: valid_extensions.to_sentence]
     end
 
     def content_type_error_params(content_type)
-      [:invalid_content_type, content: format_param(content_type), permitted: valid_content_types.join(", ")]
+      [:invalid_content_type, content: format_param(content_type), permitted: valid_content_types.to_sentence]
     end
 
     def invalid_extension?(extension)
@@ -76,7 +76,7 @@ module Refile
     end
 
     def format_param(param)
-      param.empty? ? "an empty" : param
+      param.empty? ? I18n.t('refile.empty_param') : param
     end
   end
 end

--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -76,7 +76,7 @@ module Refile
     end
 
     def format_param(param)
-      param.empty? ? I18n.t('refile.empty_param') : param
+      param.empty? ? I18n.t("refile.empty_param") : param
     end
   end
 end

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -135,14 +135,18 @@ describe Refile::ActiveRecord::Attachment do
         post = klass.new
         post.document = Refile::FileDouble.new("hello", content_type: "text/plain")
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/plain.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
+        expect(post.errors[:document]).to match_array(
+          [%r{not allowed to upload text/plain.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}]
+        )
       end
 
       it "returns false and an error message when type is empty" do
         post = klass.new
         post.document = Refile::FileDouble.new("hello", content_type: "")
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload an empty.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
+        expect(post.errors[:document]).to match_array(
+          [%r{not allowed to upload an empty.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}]
+        )
       end
 
       it "returns false and error messages when it has multiple errors" do

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -135,14 +135,14 @@ describe Refile::ActiveRecord::Attachment do
         post = klass.new
         post.document = Refile::FileDouble.new("hello", content_type: "text/plain")
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/plain.+Allowed types: image/jpeg, image/gif, image/png[^,]?}])
+        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/plain.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
       end
 
       it "returns false and an error message when type is empty" do
         post = klass.new
         post.document = Refile::FileDouble.new("hello", content_type: "")
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload an empty.+Allowed types: image/jpeg, image/gif, image/png[^,]?}])
+        expect(post.errors[:document]).to match_array([%r{not allowed to upload an empty.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
       end
 
       it "returns false and error messages when it has multiple errors" do
@@ -151,7 +151,7 @@ describe Refile::ActiveRecord::Attachment do
         expect(post.valid?).to be_falsy
         expect(post.errors[:document]).to match_array(
           [
-            %r{not allowed to upload text/plain.+Allowed types: image/jpeg, image/gif, image/png[^,]?},
+            %r{not allowed to upload text/plain.+Allowed types: image/jpeg, image/gif, and image/png[^,]?},
             "is too large"
           ]
         )
@@ -194,7 +194,7 @@ describe Refile::ActiveRecord::Attachment do
         post = klass.new
         post.document = { content_type: "text/png", size: file.size }.to_json
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/png.+Allowed types: image/jpeg, image/gif, image/png[^,]?}])
+        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/png.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
       end
 
       it "returns false and an error message when type is invalid" do
@@ -202,7 +202,7 @@ describe Refile::ActiveRecord::Attachment do
         post = klass.new
         post.document = { id: file.id, content_type: "text/png", size: file.size }.to_json
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/png.+Allowed types: image/jpeg, image/gif, image/png[^,]?}])
+        expect(post.errors[:document]).to match_array([%r{not allowed to upload text/png.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
       end
 
       it "returns false and an error message when type is empty" do
@@ -210,7 +210,7 @@ describe Refile::ActiveRecord::Attachment do
         post = klass.new
         post.document = { id: file.id, content_type: "", size: file.size }.to_json
         expect(post.valid?).to be_falsy
-        expect(post.errors[:document]).to match_array([%r{not allowed to upload an empty.+Allowed types: image/jpeg, image/gif, image/png[^,]?}])
+        expect(post.errors[:document]).to match_array([%r{not allowed to upload an empty.+Allowed types: image/jpeg, image/gif, and image/png[^,]?}])
       end
 
       it "returns false when file size is zero" do

--- a/spec/refile/attachment_spec.rb
+++ b/spec/refile/attachment_spec.rb
@@ -343,7 +343,7 @@ describe Refile::Attachment do
       expect(instance.document_attacher.valid?).to be_falsy
     end
 
-    it "returns false and if valid file is attached" do
+    it "returns true if valid file is attached" do
       file = Refile::FileDouble.new("hello", content_type: "image/png")
 
       instance.document = file
@@ -357,7 +357,7 @@ describe Refile::Attachment do
       instance.document = file
 
       expect(instance.document_attacher.valid?).to be_falsy
-      expect(instance.document_attacher.errors).to eq([:invalid_content_type])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_content_type, anything]]
     end
 
     it "returns false and sets errors if file with zero byte is uploaded" do
@@ -511,7 +511,7 @@ describe Refile::Attachment do
       file = Refile::FileDouble.new("hello", "hello.php")
       instance.document = file
 
-      expect(instance.document_attacher.errors).to eq([:invalid_extension])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_extension, anything]]
       expect(instance.document).to be_nil
     end
 
@@ -519,7 +519,7 @@ describe Refile::Attachment do
       file = Refile::FileDouble.new("hello")
       instance.document = file
 
-      expect(instance.document_attacher.errors).to eq([:invalid_extension])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_extension, anything]]
       expect(instance.document).to be_nil
     end
   end
@@ -539,7 +539,7 @@ describe Refile::Attachment do
       file = Refile::FileDouble.new("hello", content_type: "application/php")
       instance.document = file
 
-      expect(instance.document_attacher.errors).to eq([:invalid_content_type])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_content_type, anything]]
       expect(instance.document).to be_nil
     end
 
@@ -547,7 +547,7 @@ describe Refile::Attachment do
       file = Refile::FileDouble.new("hello")
       instance.document = file
 
-      expect(instance.document_attacher.errors).to eq([:invalid_content_type])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_content_type, anything]]
       expect(instance.document).to be_nil
     end
   end
@@ -567,7 +567,7 @@ describe Refile::Attachment do
       file = Refile::FileDouble.new("hello", content_type: "application/php")
       instance.document = file
 
-      expect(instance.document_attacher.errors).to eq([:invalid_content_type])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_content_type, anything]]
       expect(instance.document).to be_nil
     end
 
@@ -575,7 +575,7 @@ describe Refile::Attachment do
       file = Refile::FileDouble.new("hello")
       instance.document = file
 
-      expect(instance.document_attacher.errors).to eq([:invalid_content_type])
+      expect(instance.document_attacher.errors).to match_array [[:invalid_content_type, anything]]
       expect(instance.document).to be_nil
     end
   end

--- a/spec/refile/features/direct_upload_spec.rb
+++ b/spec/refile/features/direct_upload_spec.rb
@@ -58,6 +58,6 @@ feature "Direct HTTP post file uploads", :js do
     click_button "Create"
 
     expect(page).to have_selector(".field_with_errors")
-    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, image/png.")
+    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, and image/png.")
   end
 end

--- a/spec/refile/features/direct_upload_spec.rb
+++ b/spec/refile/features/direct_upload_spec.rb
@@ -58,6 +58,6 @@ feature "Direct HTTP post file uploads", :js do
     click_button "Create"
 
     expect(page).to have_selector(".field_with_errors")
-    expect(page).to have_content("Image has an invalid file format")
+    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, image/png.")
   end
 end

--- a/spec/refile/features/normal_upload_spec.rb
+++ b/spec/refile/features/normal_upload_spec.rb
@@ -31,7 +31,7 @@ feature "Normal HTTP Post file uploads" do
     click_button "Create"
 
     expect(page).to have_selector(".field_with_errors")
-    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, image/png.")
+    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, and image/png.")
   end
 
   scenario "Fail to upload a file that has the wrong format then submit" do
@@ -41,7 +41,7 @@ feature "Normal HTTP Post file uploads" do
     click_button "Create"
 
     expect(page).to have_selector(".field_with_errors")
-    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, image/png.")
+    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, and image/png.")
     click_button "Create"
     expect(page).to have_selector("h1", text: "A cool post")
     expect(page).not_to have_link("Document")

--- a/spec/refile/features/normal_upload_spec.rb
+++ b/spec/refile/features/normal_upload_spec.rb
@@ -31,7 +31,7 @@ feature "Normal HTTP Post file uploads" do
     click_button "Create"
 
     expect(page).to have_selector(".field_with_errors")
-    expect(page).to have_content("Image has an invalid file format")
+    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, image/png.")
   end
 
   scenario "Fail to upload a file that has the wrong format then submit" do
@@ -41,7 +41,7 @@ feature "Normal HTTP Post file uploads" do
     click_button "Create"
 
     expect(page).to have_selector(".field_with_errors")
-    expect(page).to have_content("Image has an invalid file format")
+    expect(page).to have_content("You are not allowed to upload text/plain file format. Allowed types: image/jpeg, image/gif, image/png.")
     click_button "Create"
     expect(page).to have_selector("h1", text: "A cool post")
     expect(page).not_to have_link("Document")


### PR DESCRIPTION
This PR implements the custom validation message, which return the invalid extension or type that the user is trying to upload and shows the allowed ones.