### PR TITLE
Fix 'validate' method to ignore the encoding part in content type

### DIFF
--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -38,8 +38,7 @@ module Refile
     end
 
     def content_type
-      content_type = Presence[@metadata[:content_type] || read(:content_type)]
-      content_type.split(";").first if content_type
+      Presence[@metadata[:content_type] || read(:content_type)]
     end
 
     def cache_id

--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -38,7 +38,8 @@ module Refile
     end
 
     def content_type
-      Presence[@metadata[:content_type] || read(:content_type)]
+      content_type = Presence[@metadata[:content_type] || read(:content_type)]
+      content_type.split(";").first if content_type
     end
 
     def cache_id

--- a/lib/refile/attachment_definition.rb
+++ b/lib/refile/attachment_definition.rb
@@ -47,6 +47,7 @@ module Refile
     def validate(attacher)
       extension = attacher.extension.to_s.downcase
       content_type = attacher.content_type.to_s.downcase
+      content_type = content_type.split(";").first unless content_type.empty?
 
       errors = []
       errors << extension_error_params(extension) if invalid_extension?(extension)

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -167,6 +167,13 @@ describe Refile::ActiveRecord::Attachment do
         expect(post.valid?).to be_truthy
         expect(post.errors[:document]).to be_empty
       end
+
+      it "returns true when an encoding is appended to a valid type" do
+        post = klass.new
+        post.document = Refile::FileDouble.new("hello", content_type: "image/png;charset=UTF-8")
+        expect(post.valid?).to be_truthy
+        expect(post.errors[:document]).to be_empty
+      end
     end
 
     context "when file is required" do
@@ -229,6 +236,14 @@ describe Refile::ActiveRecord::Attachment do
         file = Refile.cache.upload(StringIO.new("hello"))
         post = klass.new
         post.document = { id: file.id, content_type: "image/png", size: file.size }.to_json
+        expect(post.valid?).to be_truthy
+        expect(post.errors[:document]).to be_empty
+      end
+
+      it "returns true when an encoding is appended to a valid type" do
+        file = Refile.cache.upload(StringIO.new("hello"))
+        post = klass.new
+        post.document = { id: file.id, content_type: "image/png;charset=UTF-8", size: file.size }.to_json
         expect(post.valid?).to be_truthy
         expect(post.errors[:document]).to be_empty
       end


### PR DESCRIPTION
This PR fixes the `Attacher#content_type` method, in a way that if an **encoding** is appended to content-type response header, now it will be ignored and for now on valid images will pass the validation.

#431 