### PR TITLE
Support multiple file upload in POROs

### DIFF
--- a/lib/refile.rb
+++ b/lib/refile.rb
@@ -491,6 +491,7 @@ module Refile
   require "refile/attachment_definition"
   require "refile/attacher"
   require "refile/attachment"
+  require "refile/attachment/multiple_attachments"
   require "refile/random_hasher"
   require "refile/file"
   require "refile/custom_logger"

--- a/lib/refile/attachment.rb
+++ b/lib/refile/attachment.rb
@@ -104,5 +104,63 @@ module Refile
 
       include mod
     end
+
+    # Macro which generates accessors in pure Ruby classes for assigning
+    # multiple attachments at once. This is primarily useful together with
+    # multiple file uploads. There is also an Active Record version of
+    # this macro.
+    #
+    # The name of the generated accessors will be the name of the association
+    # (represented by an attribute accessor) and the name of the attachment in
+    # the associated class. So if a `Post` accepts attachments for `images`, and
+    # the attachment in the `Image` class is named `file`, then the accessors will
+    # be named `images_files`.
+    #
+    # @example in associated class
+    #   class Document
+    #     extend Refile::Attachment
+    #     attr_accessor :file_id
+    #
+    #     attachment :file
+    #
+    #     def initialize(attributes = {})
+    #       self.file = attributes[:file]
+    #     end
+    #   end
+    #
+    # @example in class
+    #   class Post
+    #     extend Refile::Attachment
+    #     include ActiveModel::Model
+    #
+    #     attr_accessor :documents
+    #
+    #     accepts_attachments_for :documents, accessor_prefix: 'documents_files', collection_class: Document
+    #
+    #     def initialize(attributes = {})
+    #       @documents = attributes[:documents] || []
+    #     end
+    #   end
+    #
+    # @example in form
+    #   <%= form_for @post do |form| %>
+    #     <%= form.attachment_field :documents_files, multiple: true %>
+    #   <% end %>
+    #
+    # @param [Symbol]  collection_name      Name of the association
+    # @param [Class]   collection_class     Associated class
+    # @param [String]  accessor_prefix      Name of the generated accessors
+    # @param [Symbol]  attachment           Name of the attachment in the associated class
+    # @param [Boolean] append               If true, new files are appended instead of replacing the entire list of associated classes.
+    # @return [void]
+    def accepts_attachments_for(collection_name, collection_class:, accessor_prefix:, attachment: :file, append: false)
+      include MultipleAttachments.new(
+        collection_name,
+        collection_class: collection_class,
+        name: accessor_prefix,
+        attachment: attachment,
+        append: append
+      )
+    end
   end
 end

--- a/lib/refile/attachment/multiple_attachments.rb
+++ b/lib/refile/attachment/multiple_attachments.rb
@@ -1,0 +1,54 @@
+module Refile
+  module Attachment
+    # Builds a module to be used by "accepts_attachments_for"
+    #
+    # @api private
+    module MultipleAttachments
+      def self.new(collection_name, collection_class:, name:, attachment:, append:, &block)
+        Module.new do
+          define_method :"#{name}_attachment_definition" do
+            collection_class.send("#{attachment}_attachment_definition")
+          end
+
+          define_method :"#{name}_data" do
+            collection = send(collection_name)
+
+            all_attachers_valid = collection.all? do |record|
+              record.send("#{attachment}_attacher").valid?
+            end
+
+            collection.map(&:"#{attachment}_data") if all_attachers_valid
+          end
+
+          define_method :"#{name}" do
+            send(collection_name).map(&attachment)
+          end
+
+          define_method :"#{name}=" do |files|
+            cache, files = [files].flatten.partition { |file| file.is_a?(String) }
+            cache = Refile.parse_json(cache.first) || []
+            cache = cache.reject(&:empty?)
+            files = files.compact
+
+            if not append and (!files.empty? or !cache.empty?)
+              send("#{collection_name}=", [])
+            end
+
+            collection = send(collection_name)
+
+            if files.empty? and !cache.empty?
+              cache.each do |file|
+                collection << collection_class.new(attachment => file.to_json)
+              end
+            else
+              files.each do |file|
+                collection << collection_class.new(attachment => file)
+              end
+            end
+          end
+          module_eval(&block) if block_given?
+        end
+      end
+    end
+  end
+end

--- a/spec/refile/app_spec.rb
+++ b/spec/refile/app_spec.rb
@@ -128,7 +128,7 @@ describe Refile::App do
         end
 
         context "with a valid `expires_at`" do
-          let(:expires_at) { (Time.now + 1.minute).to_i }
+          let(:expires_at) { (Time.now + 1.seconds).to_i }
 
           it "accepts the expires at" do
             token =

--- a/spec/refile/support/accepts_attachments_for_shared_examples.rb
+++ b/spec/refile/support/accepts_attachments_for_shared_examples.rb
@@ -1,0 +1,232 @@
+RSpec.shared_examples "accepts_attachments_for" do
+  describe "#:association_:name=" do
+    it "builds records from assigned files" do
+      post.documents_files = [
+        Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+        Refile::FileDouble.new("world", content_type: "image/jpeg")
+      ]
+      post.save!
+
+      expect(post.documents.size).to eq(2)
+      expect(post.documents[0].file.read).to eq("hello")
+      expect(post.documents[1].file.read).to eq("world")
+    end
+
+    it "clears previously assigned files" do
+      post.documents_files = [
+        Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+        Refile::FileDouble.new("world", content_type: "image/jpeg")
+      ]
+      post.save!
+      post.update_attributes! documents_files: [
+        Refile::FileDouble.new("foo", content_type: "image/jpeg")
+      ]
+
+      expect(post.documents[0].file.read).to eq("foo")
+      expect(post.documents.size).to eq(1)
+    end
+
+    it "ignores nil assigned files" do
+      post.documents_files = [
+        Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+        nil,
+        nil
+      ]
+      post.save!
+
+      expect(post.documents.size).to eq(1)
+      expect(post.documents[0].file.read).to eq("hello")
+    end
+
+    it "builds records from cache" do
+      post.documents_files = [
+        [
+          {
+            id: Refile.cache.upload(Refile::FileDouble.new("hello")).id,
+            filename: "some.jpg",
+            content_type: "image/jpeg",
+            size: 1234
+          },
+          {
+            id: Refile.cache.upload(Refile::FileDouble.new("world")).id,
+            filename: "some.jpg",
+            content_type: "image/jpeg",
+            size: 1234
+          }
+        ].to_json
+      ]
+      post.save!
+
+      expect(post.documents.size).to eq(2)
+      expect(post.documents[0].file.read).to eq("hello")
+      expect(post.documents[1].file.read).to eq("world")
+    end
+
+    it "prefers uploaded files over cache when both are present" do
+      post.documents_files = [
+        [
+          {
+            id: Refile.cache.upload(Refile::FileDouble.new("moo")).id,
+            filename: "some.jpg",
+            content_type: "image/jpeg",
+            size: 1234
+          }
+        ].to_json,
+        Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+        Refile::FileDouble.new("world", content_type: "image/jpeg")
+      ]
+      post.save!
+
+      expect(post.documents.size).to eq(2)
+      expect(post.documents[0].file.read).to eq("hello")
+      expect(post.documents[1].file.read).to eq("world")
+    end
+
+    it "ignores empty caches" do
+      post.documents_files = [
+        [
+          {
+            id: Refile.cache.upload(Refile::FileDouble.new("moo")).id,
+            filename: "some.jpg",
+            content_type: "image/jpeg",
+            size: 1234
+          },
+          {},
+          {}
+        ].to_json
+      ]
+      post.save!
+
+      expect(post.documents.size).to eq(1)
+      expect(post.documents[0].file.read).to eq("moo")
+    end
+
+    it "ignores caches with malformed json" do
+      post.documents_files = [
+        "[{id: 'this is a ruby hash'}]"
+      ]
+
+      expect(post.documents.size).to be_zero
+    end
+
+    context "with append: true" do
+      let(:options) { { append: true } }
+
+      it "appends to previously assigned files" do
+        post.documents_files = [
+          Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+          Refile::FileDouble.new("world", content_type: "image/jpeg")
+        ]
+        post.save!
+        post.update_attributes! documents_files: [
+          Refile::FileDouble.new("foo", content_type: "image/jpeg")
+        ]
+
+        expect(post.documents.size).to eq(3)
+        expect(post.documents[0].file.read).to eq("hello")
+        expect(post.documents[1].file.read).to eq("world")
+        expect(post.documents[2].file.read).to eq("foo")
+      end
+
+      it "appends to previously assigned files with cached files" do
+        post.documents_files = [
+          Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+          Refile::FileDouble.new("world", content_type: "image/jpeg")
+        ]
+        post.save!
+        post.update_attributes! documents_files: [
+          [{
+            id: Refile.cache.upload(Refile::FileDouble.new("hello world")).id,
+            filename: "some.jpg",
+            content_type: "image/jpeg",
+            size: 1234
+          }].to_json
+        ]
+
+        expect(post.documents.size).to eq(3)
+        expect(post.documents[0].file.read).to eq("hello")
+        expect(post.documents[1].file.read).to eq("world")
+        expect(post.documents[2].file.read).to eq("hello world")
+      end
+
+      it "appends to previously cached files with cached files" do
+        post.documents_files = [
+          [
+            {
+              id: Refile.cache.upload(Refile::FileDouble.new("moo")).id,
+              filename: "some1.jpg",
+              content_type: "image/jpeg",
+              size: 123
+            }
+          ].to_json
+        ]
+        post.documents_files = [
+          [
+            {
+              id: Refile.cache.upload(Refile::FileDouble.new("hello")).id,
+              filename: "some2.jpg",
+              content_type: "image/jpeg",
+              size: 1234
+            }
+          ].to_json
+        ]
+        post.save!
+
+        expect(post.documents.size).to eq(2)
+        expect(post.documents[0].file.read).to eq("moo")
+        expect(post.documents[1].file.read).to eq("hello")
+      end
+    end
+  end
+
+  describe "#:association_:name_data" do
+    it "returns metadata for all files" do
+      post.documents_files = [
+        nil,
+        Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+        Refile::FileDouble.new("world", content_type: "image/jpeg")
+      ]
+      data = post.documents_files_data
+
+      expect(data.size).to eq(2)
+      expect(Refile.cache.read(data[0][:id])).to eq("hello")
+      expect(Refile.cache.read(data[1][:id])).to eq("world")
+    end
+
+    context "when there are invalid files" do
+      it "only returns metadata for valid files " do
+        invalid_file = Refile::FileDouble.new("world", content_type: "text/plain")
+
+        post.documents_files = [invalid_file]
+        data = post.documents_files_data
+
+        expect(data).to be_nil
+      end
+    end
+  end
+
+  describe "#:association_:name" do
+    it "builds records from assigned files" do
+      post.documents_files = [
+        Refile::FileDouble.new("hello", content_type: "image/jpeg"),
+        Refile::FileDouble.new("world", content_type: "image/jpeg")
+      ]
+
+      expect(post.documents_files.size).to eq(2)
+      expect(post.documents_files[0].read).to eq("hello")
+      expect(post.documents_files[1].read).to eq("world")
+    end
+  end
+
+  describe "#:association_:name_attachment_definition" do
+    it "returns attachment definition" do
+      post.documents_files = [
+        Refile::FileDouble.new("hello", content_type: "image/jpeg")
+      ]
+
+      definition = post.documents_files_attachment_definition
+      expect(definition).to be_a Refile::AttachmentDefinition
+      expect(definition.name).to eq(:file)
+    end
+  end
+end


### PR DESCRIPTION
This pull request implements a new `accepts_attachments_for` macro that works with pure Ruby classes. Previously, this macro only worked with Active Record classes. I also kept the Active Record macro.

To accomplish that:

- Macro code has been extracted to a new method called `Refile::Attachment::MultipleUploads#new`. This method generates a module that can be used by both versions of `accepts_attachments_for`.
- To use a PORO, users of the gem will need to implement an interface that's similar to Active Record's. See the README.md file for more details.
- I've moved macro specs to an RSpec shared example and also improved the test coverage.

Also, I had to change the valid `expires_at` from 1 minute to 1 second in the `app_spec.rb` file, in order to avoid CI build failing.

#446 