### PR TITLE
Support Publishing JS as an NPM Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,9 @@ simply include it like this:
 //= require refile
 ```
 
+You can also separately install the JavaScript library with NPM or Yarn using
+`npm install --save refile` or `yarn add refile`.
+
 Otherwise you can grab a copy [here](https://raw.githubusercontent.com/refile/refile/master/app/assets/javascripts/refile.js).
 Be sure to always update your copy of this file when you upgrade to the latest
 Refile version.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "refile",
+  "version": "0.6.2",
+  "description": "Refile is a modern file upload library for Ruby applications. It is simple, yet powerful.",
+  "main": "app/assets/javascripts/refile.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/refile/refile.git"
+  },
+  "files": [
+    "app/assets/javascripts/refile.js"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/refile/refile#readme"
+}


### PR DESCRIPTION
This would close out #555 (if it gets pulled in). I published this @ https://www.npmjs.com/package/testing-refile-tristanoneil for testing purposes so you can try it out with `npm install --save testing-refile-tristanoneil`. The package only includes `refile.js` in addition to `README.md`, `History.md`, `LICENSE.txt` and `package.json` (`npm` publishes these files by default). It does appear that [`refile`](https://www.npmjs.com/package/refile) is already taken on NPM so the package name would likely have to be changed, I'll leave that up to the maintainer though as to what it should be.