### PR TITLE
Allow assignment of attachment that was previously nil

### DIFF
--- a/lib/refile/attacher.rb
+++ b/lib/refile/attacher.rb
@@ -73,6 +73,7 @@ module Refile
     end
 
     def set(value)
+      self.remove = false
       case value
         when nil then self.remove = true
         when String, Hash then retrieve!(value)

--- a/spec/refile/attachment/active_record_spec.rb
+++ b/spec/refile/attachment/active_record_spec.rb
@@ -273,6 +273,18 @@ describe Refile::ActiveRecord::Attachment do
       expect(Refile.store.read(post.document.id)).to eq("hello")
       expect(post.document.id).not_to be eq old_document.id
     end
+
+    it "replaces a attachment which was nil" do
+      post = klass.new
+      post.document = nil
+      post.save
+
+      post.document = Refile::FileDouble.new("hello")
+      post.save
+
+      expect(Refile.store.read(post.document.id)).to eq("hello")
+      expect(post.document).not_to be_nil
+    end
   end
 
   describe "#destroy" do


### PR DESCRIPTION
Closes: https://github.com/refile/refile/issues/579

Currently it's not possible to assign a attachment that was previously
set to `nil` without reinitializing the object.

Previously the following code would not work:

```ruby
post.document = nil
post.save
post.document = Refile::DoubleFile.new("hello")
post.save

post.document # => still nil
```

This bug was caused by the `remove` attribute which was set to `true`
when `nil` was assigned but never reset to `false` when a valid
attachment was assigned afterwards.

The previous workaround was to re-create the object eq. calling
something like `post = Post.find(post.id)`