### PR TITLE
Fix typo of migration command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Generate a migration:
 
 ``` sh
 rails generate migration add_profile_image_to_users profile_image_id:string &&
-profile_image_filename:string && profile_image_content_size:string &&
+profile_image_filename:string && profile_image_size:string &&
 profile_image_content_type:string
 
 rake db:migrate


### PR DESCRIPTION
I found a typo in this README.

- invalid: `profile_image_content_size`
- valid: `profile_image_size`