### PR TITLE
Add gemfiles for another rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,20 @@ rvm:
   - 2.4.5
   - 2.5.3
   - 2.6.0
-  - jruby-9.1.17.0
   - jruby-9.2.5.0
 
 gemfile:
-  - gemfiles/Gemfile.rest-client.1.8
-  - gemfiles/Gemfile.rest-client.2.0
-  - gemfiles/Gemfile.rest-client.2.1
+  - gemfiles/rails_5.0/Gemfile.rest-client.1.8
+  - gemfiles/rails_5.0/Gemfile.rest-client.2.0
+  - gemfiles/rails_5.0/Gemfile.rest-client.2.1
+
+  - gemfiles/rails_5.1/Gemfile.rest-client.1.8
+  - gemfiles/rails_5.1/Gemfile.rest-client.2.0
+  - gemfiles/rails_5.1/Gemfile.rest-client.2.1
+
+  - gemfiles/rails_5.2/Gemfile.rest-client.1.8
+  - gemfiles/rails_5.2/Gemfile.rest-client.2.0
+  - gemfiles/rails_5.2/Gemfile.rest-client.2.1
 
 cache: bundler
 

--- a/gemfiles/rails_5.0/Gemfile.rest-client.1.8
+++ b/gemfiles/rails_5.0/Gemfile.rest-client.1.8
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gemspec path: '../../'
+
+gem "webmock", "~> 3.5.1"
+gem "bundler", "~> 1.6"
+gem "rake", "< 11.0"
+gem "rspec", "~> 3.0"
+gem "rspec-rails", "~> 3.3"
+gem "jquery-rails"
+gem "capybara"
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "rails", "~> 5.0.7.1"
+gem "sqlite3",                                      platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 50.2", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~> 0.49.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "i18n", "~> 1.2.0", platforms: [:jruby]
+gem "rest-client", "~> 1.8"

--- a/gemfiles/rails_5.0/Gemfile.rest-client.2.0
+++ b/gemfiles/rails_5.0/Gemfile.rest-client.2.0
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gemspec path: '../'
+gemspec path: '../../'
 
 gem "webmock", "~> 3.5.1"
 gem "bundler", "~> 1.6"
@@ -13,9 +13,9 @@ gem "pry"
 gem "pry-byebug", platforms: [:mri]
 gem "aws-sdk"
 gem "rack-test", "~> 0.6.2"
-gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.0.7.1"
 gem "sqlite3",                                      platforms: [:ruby]
-gem "activerecord-jdbcsqlite3-adapter", "5.0.pre1", platforms: [:jruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 50.2", platforms: [:jruby]
 gem "poltergeist"
 gem "yard"
 gem "rubocop", "~> 0.49.0"
@@ -23,4 +23,4 @@ gem "puma"
 gem "mini_magick"
 gem "simple_form"
 gem "i18n", "~> 1.2.0", platforms: [:jruby]
-gem 'rest-client', '~> 2.0'
+gem "rest-client", "~> 2.0"

--- a/gemfiles/rails_5.0/Gemfile.rest-client.2.1
+++ b/gemfiles/rails_5.0/Gemfile.rest-client.2.1
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gemspec path: '../'
+gemspec path: '../../'
 
 gem "webmock", "~> 3.5.1"
 gem "bundler", "~> 1.6"
@@ -13,9 +13,9 @@ gem "pry"
 gem "pry-byebug", platforms: [:mri]
 gem "aws-sdk"
 gem "rack-test", "~> 0.6.2"
-gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.0.7.1"
 gem "sqlite3",                                      platforms: [:ruby]
-gem "activerecord-jdbcsqlite3-adapter", "5.0.pre1", platforms: [:jruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 50.2", platforms: [:jruby]
 gem "poltergeist"
 gem "yard"
 gem "rubocop", "~> 0.49.0"
@@ -23,4 +23,4 @@ gem "puma"
 gem "mini_magick"
 gem "simple_form"
 gem "i18n", "~> 1.2.0", platforms: [:jruby]
-gem 'rest-client', '~> 2.1.0.rc1'
+gem "rest-client", "~> 2.1.0.rc1"

--- a/gemfiles/rails_5.1/Gemfile.rest-client.1.8
+++ b/gemfiles/rails_5.1/Gemfile.rest-client.1.8
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gemspec path: '../../'
+
+gem "webmock", "~> 3.5.1"
+gem "bundler", "~> 1.6"
+gem "rake", "< 11.0"
+gem "rspec", "~> 3.0"
+gem "rspec-rails", "~> 3.3"
+gem "jquery-rails"
+gem "capybara"
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "rails", "~> 5.1.6.1"
+gem "sqlite3",                                      platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 51.2", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~> 0.49.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "i18n", "~> 1.2.0", platforms: [:jruby]
+gem "rest-client", "~> 1.8"

--- a/gemfiles/rails_5.1/Gemfile.rest-client.2.0
+++ b/gemfiles/rails_5.1/Gemfile.rest-client.2.0
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gemspec path: '../../'
+
+gem "webmock", "~> 3.5.1"
+gem "bundler", "~> 1.6"
+gem "rake", "< 11.0"
+gem "rspec", "~> 3.0"
+gem "rspec-rails", "~> 3.3"
+gem "jquery-rails"
+gem "capybara"
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "rails", "~> 5.1.6.1"
+gem "sqlite3",                                      platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 51.2", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~> 0.49.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "i18n", "~> 1.2.0", platforms: [:jruby]
+gem "rest-client", "~> 2.0"

--- a/gemfiles/rails_5.1/Gemfile.rest-client.2.1
+++ b/gemfiles/rails_5.1/Gemfile.rest-client.2.1
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gemspec path: '../../'
+
+gem "webmock", "~> 3.5.1"
+gem "bundler", "~> 1.6"
+gem "rake", "< 11.0"
+gem "rspec", "~> 3.0"
+gem "rspec-rails", "~> 3.3"
+gem "jquery-rails"
+gem "capybara"
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "rails", "~> 5.1.6.1"
+gem "sqlite3",                                      platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 51.2", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~> 0.49.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "i18n", "~> 1.2.0", platforms: [:jruby]
+gem "rest-client", "~> 2.1.0.rc1"

--- a/gemfiles/rails_5.2/Gemfile.rest-client.1.8
+++ b/gemfiles/rails_5.2/Gemfile.rest-client.1.8
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gemspec path: '../'
+gemspec path: '../../'
 
 gem "webmock", "~> 3.5.1"
 gem "bundler", "~> 1.6"
@@ -13,9 +13,9 @@ gem "pry"
 gem "pry-byebug", platforms: [:mri]
 gem "aws-sdk"
 gem "rack-test", "~> 0.6.2"
-gem "rails", "~> 5.0.0"
+gem "rails", "~> 5.2.2"
 gem "sqlite3",                                      platforms: [:ruby]
-gem "activerecord-jdbcsqlite3-adapter", "5.0.pre1", platforms: [:jruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 52.1", platforms: [:jruby]
 gem "poltergeist"
 gem "yard"
 gem "rubocop", "~> 0.49.0"
@@ -23,4 +23,4 @@ gem "puma"
 gem "mini_magick"
 gem "simple_form"
 gem "i18n", "~> 1.2.0", platforms: [:jruby]
-gem 'rest-client', '~> 1.8'
+gem "rest-client", "~> 1.8"

--- a/gemfiles/rails_5.2/Gemfile.rest-client.2.0
+++ b/gemfiles/rails_5.2/Gemfile.rest-client.2.0
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gemspec path: '../../'
+
+gem "webmock", "~> 3.5.1"
+gem "bundler", "~> 1.6"
+gem "rake", "< 11.0"
+gem "rspec", "~> 3.0"
+gem "rspec-rails", "~> 3.3"
+gem "jquery-rails"
+gem "capybara"
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "rails", "~> 5.2.2"
+gem "sqlite3",                                      platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 52.1", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~> 0.49.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "i18n", "~> 1.2.0", platforms: [:jruby]
+gem "rest-client", "~> 2.0"

--- a/gemfiles/rails_5.2/Gemfile.rest-client.2.1
+++ b/gemfiles/rails_5.2/Gemfile.rest-client.2.1
@@ -1,0 +1,26 @@
+source "https://rubygems.org"
+
+gemspec path: '../../'
+
+gem "webmock", "~> 3.5.1"
+gem "bundler", "~> 1.6"
+gem "rake", "< 11.0"
+gem "rspec", "~> 3.0"
+gem "rspec-rails", "~> 3.3"
+gem "jquery-rails"
+gem "capybara"
+gem "pry"
+gem "pry-byebug", platforms: [:mri]
+gem "aws-sdk"
+gem "rack-test", "~> 0.6.2"
+gem "rails", "~> 5.2.2"
+gem "sqlite3",                                      platforms: [:ruby]
+gem "activerecord-jdbcsqlite3-adapter", "~> 52.1", platforms: [:jruby]
+gem "poltergeist"
+gem "yard"
+gem "rubocop", "~> 0.49.0"
+gem "puma"
+gem "mini_magick"
+gem "simple_form"
+gem "i18n", "~> 1.2.0", platforms: [:jruby]
+gem "rest-client", "~> 2.1.0.rc1"

--- a/spec/refile/active_record_helper.rb
+++ b/spec/refile/active_record_helper.rb
@@ -8,7 +8,7 @@ ActiveRecord::Base.establish_connection(
   verbosity: "quiet"
 )
 
-class TestMigration < ActiveRecord::Migration
+class TestMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :posts, force: true do |t|
       t.integer :user_id

--- a/spec/refile/test_app/app/controllers/presigned_posts_controller.rb
+++ b/spec/refile/test_app/app/controllers/presigned_posts_controller.rb
@@ -19,12 +19,12 @@ class PresignedPostsController < ApplicationController
         File.open(File.join(Refile.backends["limited_cache"].directory, params[:id]), "wb") do |file|
           file.write(params[:file].read)
         end
-        render text: "token accepted"
+        render plain: "token accepted"
       else
-        render text: "too large", status: 413
+        render plain: "too large", status: 413
       end
     else
-      render text: "token rejected", status: 403
+      render plain: "token rejected", status: 403
     end
   end
 end


### PR DESCRIPTION
This PR enables CI runners for the following rails versions:

- 5.0
- 5.1
- 5.2

... and removes the jruby-9.1 from it...