### PR TITLE
chore: simple fix in the documentation for active record's accepts_attachments_for

### DIFF
--- a/lib/refile/attachment/active_record.rb
+++ b/lib/refile/attachment/active_record.rb
@@ -64,7 +64,7 @@ module Refile
       #
       # @example in associated model
       #   class Image
-      #     attachment :image
+      #     attachment :file
       #   end
       #
       # @example in form


### PR DESCRIPTION
This is a very simple fix, but it can cause confusion while reading the source code or using docs.