### PR TITLE
Support new Quality Option for Processor

### DIFF
--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -44,22 +44,22 @@ module Refile
 
     get "/:token/:backend/:processor/:id/:file_basename.:extension" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, format: params[:extension])
+      stream_file processor.call(file, format: params[:extension], quality: params[:quality])
     end
 
     get "/:token/:backend/:processor/:id/:filename" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file)
+      stream_file processor.call(file, quality: params[:quality])
     end
 
     get "/:token/:backend/:processor/*/:id/:file_basename.:extension" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension])
+      stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension], quality: params[:quality])
     end
 
     get "/:token/:backend/:processor/*/:id/:filename" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, *params[:splat].first.split("/"))
+      stream_file processor.call(file, *params[:splat].first.split("/"), quality: params[:quality])
     end
 
     options "/:backend" do


### PR DESCRIPTION
This patch adds support for a new `quality` parameter that will be forwarded to the image processor.

This patch requires https://github.com/refile/refile-mini_magick/pull/23

**Specs**

Specs are missing since I couldn't find any information on how to run them and I was also not sure how the specs are build up. I can see that there are some dummy processors used that work with strings rather than images. I would love to get some help and add specs for the new parameter.

**Version Requirements**

Since this change requires a specific version of the `refile-mini_magick` gem we would need to somehow ensure that the correct version is present.

Since the gem dependency points from `refile-mini_magick` to `refile` I'm not sure how we would enforce this.

Other processors would also now need to support this option which might makes no sense for non-image based processors.

Maybe another patch is needed first that exposes the supported options on each image processor. I'll love to hear your thoughts on how to solve this problem.