### PR TITLE
Support Rails Credentials

### DIFF
--- a/lib/refile/rails.rb
+++ b/lib/refile/rails.rb
@@ -27,12 +27,11 @@ module Refile
     end
 
     initializer "refile.secret_key" do |app|
-      Refile.secret_key ||= if app.respond_to?(:secrets)
-        app.secrets.secret_key_base
-      elsif app.config.respond_to?(:secret_key_base)
-        app.config.secret_key_base
-      elsif app.config.respond_to?(:secret_token)
-        app.config.secret_token
+      Refile.secret_key ||= begin
+        secret_key_base = app.config.secret_key_base
+        secret_token = app.config.secret_token if app.config.respond_to?(:secret_token)
+
+        secret_key_base || secret_token
       end
     end
   end


### PR DESCRIPTION
This patch simplifies the logic to find the apps `secret_key_base` by relying on `app.config.secret_key_base` which will take care of looking up the `secret_key_base` in the ENV, secrets and credentials as stated in the [rails docs](https://api.rubyonrails.org/v5.2.1/classes/Rails/Application.html#method-i-secret_key_base):

> We look for it first in ENV, then credentials.secret_key_base, and finally secrets.secret_key_base. For most applications, the correct place to store it is in the encrypted credentials file.

**Assumptions**

I didn't find any concrete information on which rails versions are supporter by Refile so I assumes that the minimal version is the one specified in `gemfiles/Gemfile_Rails_5_0`.

I also left the check for `config.secret_key` in but I don't fully understand the purpose of it. Is it to support the legacy `secret_key` or is it here to support a Refile specific `secret_key`, in that case wouldn't it  make more sense to use this even if a `secret_key_base` is present?

**Specs**

I couldn't find any specs that check the lookup order of the
`secret_key_base` but I would be open to add some one my assumptions above are confirmed.

Closes https://github.com/refile/refile/issues/593