### PR TITLE
Support Rails Credentials

### DIFF
--- a/lib/refile/rails.rb
+++ b/lib/refile/rails.rb
@@ -27,13 +27,21 @@ module Refile
     end
 
     initializer "refile.secret_key" do |app|
-      Refile.secret_key ||= if app.respond_to?(:secrets)
+      Refile.secret_key ||= if app.respond_to?(:credentials) && key_exists?(app.credentials)
+        app.credentials.secret_key_base
+      elsif app.respond_to?(:secrets) && key_exists?(app.secrets)
         app.secrets.secret_key_base
-      elsif app.config.respond_to?(:secret_key_base)
+      elsif app.config.respond_to?(:secret_key_base) && key_exists?(app.config)
         app.config.secret_key_base
       elsif app.config.respond_to?(:secret_token)
         app.config.secret_token
       end
+    end
+
+  private
+
+    def key_exists?(object)
+      object.secret_key_base.present?
     end
   end
 end


### PR DESCRIPTION
This patch adds support for the credentials feature introduced in rails 5.2.

The code patch has been updated to also check that the `secret_key_base` is also actually set. This is more in-line with the logic of `config.secret_key_base` in [Rails 5.2](https://api.rubyonrails.org/v5.2.1/classes/Rails/Application.html#method-i-secret_key_base) and whit what other gems like [Devise](https://github.com/plataformatec/devise/blob/master/lib/devise/secret_key_finder.rb) do.

We can't use `config.secret_key_base` since it doesn't exist on Rails versions before 5.2.

Replaces https://github.com/refile/refile/pull/595
Closes https://github.com/refile/refile/issues/593