### PR TITLE
Revert "Support new Quality Option for Processor"

### DIFF
--- a/lib/refile/app.rb
+++ b/lib/refile/app.rb
@@ -44,22 +44,22 @@ module Refile
 
     get "/:token/:backend/:processor/:id/:file_basename.:extension" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, format: params[:extension], quality: params[:quality])
+      stream_file processor.call(file, format: params[:extension])
     end
 
     get "/:token/:backend/:processor/:id/:filename" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, quality: params[:quality])
+      stream_file processor.call(file)
     end
 
     get "/:token/:backend/:processor/*/:id/:file_basename.:extension" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension], quality: params[:quality])
+      stream_file processor.call(file, *params[:splat].first.split("/"), format: params[:extension])
     end
 
     get "/:token/:backend/:processor/*/:id/:filename" do
       halt 404 unless download_allowed?
-      stream_file processor.call(file, *params[:splat].first.split("/"), quality: params[:quality])
+      stream_file processor.call(file, *params[:splat].first.split("/"))
     end
 
     options "/:backend" do


### PR DESCRIPTION
Reverts refile/refile#594

The spec is failing:

```
$ BUNDLE_GEMFILE=gemfiles/Gemfile_Rails_5_2 bundle exec rspec spec/refile/app_spec.rb:253
WARNING: If you plan to load any of ActiveSupport's core extensions to Hash, be
sure to do so *before* loading Sinatra::Application or Sinatra::Base. If not,
you may disregard this warning.

Set SINATRA_ACTIVESUPPORT_WARNING=false in the environment to hide this warning.
Run options: include {:locations=>{"./spec/refile/app_spec.rb"=>[253]}}
F

Failures:

  1) Refile::App GET /:backend/:processor/:id/:filename applies processor with arguments
     Failure/Error: expect(last_response.status).to eq(200)

       expected: 200
            got: 500

       (compared using ==)
     # ./spec/refile/app_spec.rb:258:in `block (3 levels) in <top (required)>'

Finished in 0.04626 seconds (files took 0.81823 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/refile/app_spec.rb:253 # Refile::App GET /:backend/:processor/:id/:filename applies processor with arguments
```