### PR TITLE
Fix: [Ruby2.7] `warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call`

### DIFF
--- a/lib/refile/rails/attachment_helper.rb
+++ b/lib/refile/rails/attachment_helper.rb
@@ -6,13 +6,13 @@ module Refile
       # @see AttachmentHelper#attachment_field
       def attachment_field(method, options = {})
         self.multipart = true
-        @template.attachment_field(@object_name, method, objectify_options(options))
+        @template.attachment_field(@object_name, method, **objectify_options(options))
       end
 
       # @see AttachmentHelper#attachment_cache_field
       def attachment_cache_field(method, options = {})
         self.multipart = true
-        @template.attachment_cache_field(@object_name, method, objectify_options(options))
+        @template.attachment_cache_field(@object_name, method, **objectify_options(options))
       end
     end
 


### PR DESCRIPTION
Fixed #601 