### PR TITLE
Listen to "loadend" event instead of "load"

### DIFF
--- a/app/assets/javascripts/refile.js
+++ b/app/assets/javascripts/refile.js
@@ -43,7 +43,7 @@
 
         xhr.file = file;
 
-        xhr.addEventListener("load", function() {
+        xhr.addEventListener("loadend", function() {
           xhr.complete = true;
           if(requests.every(function(xhr) { return xhr.complete })) {
             finalizeUpload();
@@ -64,7 +64,7 @@
           dispatchEvent(input, "presign:start");
           var presignXhr = new XMLHttpRequest();
           var presignUrl = url + "?t=" + Date.now() + "." + index;
-          presignXhr.addEventListener("load", function() {
+          presignXhr.addEventListener("loadend", function() {
             dispatchEvent(input, "presign:complete");
             if(isSuccess(presignXhr)) {
               dispatchEvent(input, "presign:success");

--- a/spec/refile/features/direct_upload_spec.rb
+++ b/spec/refile/features/direct_upload_spec.rb
@@ -29,6 +29,18 @@ feature "Direct HTTP post file uploads", :js do
     expect(page).to have_content("Upload failure error")
   end
 
+  scenario "Fail to upload due to connection error" do
+    page.driver.browser.url_blacklist = ["#{Refile.app_host}/attachments"]
+
+    visit "/direct/posts/new"
+    fill_in "Title", with: "A cool post"
+    attach_file "Document", path("hello.txt")
+
+    expect(page).to have_content("Upload started")
+    expect(page).to have_content("Upload failure")
+    expect(page).to have_content("Upload complete")
+  end
+
   scenario "Upload a file after validation failure" do
     visit "/direct/posts/new"
     fill_in "Title", with: "A cool post"

--- a/spec/refile/features/presigned_upload_spec.rb
+++ b/spec/refile/features/presigned_upload_spec.rb
@@ -28,4 +28,17 @@ feature "Direct HTTP post file uploads", :js do
     expect(page).to have_content("Upload started")
     expect(page).to have_content("Upload failure too large")
   end
+
+  scenario "Fail to upload due to connection error" do
+    page.driver.browser.url_blacklist = ["#{Refile.app_host}/attachments"]
+
+    visit "/presigned/posts/new"
+    fill_in "Title", with: "A cool post"
+    attach_file "Document", path("hello.txt")
+
+    expect(page).to have_content("Presign start")
+    expect(page).to have_content("Presign complete")
+    expect(page).to have_content("Presign failure")
+    expect(page).not_to have_content("Upload started")
+  end
 end


### PR DESCRIPTION
`load` event is not fired when the request encountered an error (e.g. disconnection).
We have to listen to `loadend` event to handle such situation.
