### PR TITLE
Use Rails::Application#secret_key_base first

### DIFF
--- a/lib/refile/rails.rb
+++ b/lib/refile/rails.rb
@@ -27,7 +27,9 @@ module Refile
     end
 
     initializer "refile.secret_key" do |app|
-      Refile.secret_key ||= if app.respond_to?(:secrets)
+      Refile.secret_key ||= if app.respond_to?(:secret_key_base)
+        app.secret_key_base
+      elsif app.respond_to?(:secrets)
         app.secrets.secret_key_base
       elsif app.config.respond_to?(:secret_key_base)
         app.config.secret_key_base


### PR DESCRIPTION
Current implementation will raise error even if `ENV["SECRET_KEY_BASE"]` is set. This PR make it work by using `Rails::Application#secret_key_base`.

See also https://api.rubyonrails.org/classes/Rails/Application.html#method-i-secret_key_base

Maybe related to https://github.com/refile/refile/pull/596

Here is the results in my sample app deployed to Heroku:

```
irb(main):001:0> Rails.application.secret_key_base
=> "3b280b2ea435b3768039021b09e0362c9bafa76adf4606b121de4f28ecc630e5002acc05ce5797c3a525722cc6d5cc1408c5e24dc3ba76e27ffd7fa68eb7e7d9"
irb(main):002:0> Refile.secret_key
=> "3b280b2ea435b3768039021b09e0362c9bafa76adf4606b121de4f28ecc630e5002acc05ce5797c3a525722cc6d5cc1408c5e24dc3ba76e27ffd7fa68eb7e7d9"
irb(main):003:0> ENV["SECRET_KEY_BASE"]
=> "3b280b2ea435b3768039021b09e0362c9bafa76adf4606b121de4f28ecc630e5002acc05ce5797c3a525722cc6d5cc1408c5e24dc3ba76e27ffd7fa68eb7e7d9"
```

Without this PR, `Refile.secret_key` will be `nil`.